### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728726232,
-        "narHash": "sha256-8ZWr1HpciQsrFjvPMvZl0W+b0dilZOqXPoKa2Ux36bc=",
+        "lastModified": 1728791962,
+        "narHash": "sha256-nr5QiXwQcZmf6/auC1UpX8iAtINMtdi2mH+OkqJQVmU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d57112db877f07387ce7104b5ac346ede556d2d7",
+        "rev": "64c6325b28ebd708653dd41d88f306023f296184",
         "type": "github"
       },
       "original": {
@@ -69,11 +69,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728263287,
-        "narHash": "sha256-GJDtsxz2/zw6g/Nrp4XVWBS5IaZ7ZUkuvxPOBEDe7pg=",
+        "lastModified": 1728790083,
+        "narHash": "sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5fce10c871bab6d7d5ac9e5e7efbb3a2783f5259",
+        "rev": "5c54c33aa04df5dd4b0984b7eb861d1981009b22",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d57112db877f07387ce7104b5ac346ede556d2d7?narHash=sha256-8ZWr1HpciQsrFjvPMvZl0W%2Bb0dilZOqXPoKa2Ux36bc%3D' (2024-10-12)
  → 'github:nix-community/home-manager/64c6325b28ebd708653dd41d88f306023f296184?narHash=sha256-nr5QiXwQcZmf6/auC1UpX8iAtINMtdi2mH%2BOkqJQVmU%3D' (2024-10-13)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5fce10c871bab6d7d5ac9e5e7efbb3a2783f5259?narHash=sha256-GJDtsxz2/zw6g/Nrp4XVWBS5IaZ7ZUkuvxPOBEDe7pg%3D' (2024-10-07)
  → 'github:nix-community/nix-index-database/5c54c33aa04df5dd4b0984b7eb861d1981009b22?narHash=sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y%3D' (2024-10-13)
```