### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729787536,
-        "narHash": "sha256-4fVameZ6v9OGRE/MaGUA7Y+j0aFSDs4BjN92iqLFydI=",
+        "lastModified": 1729860693,
+        "narHash": "sha256-dqjmlFJLeyatRNgHnxUXI+qF/gG0JKaNusK3ZxF6S00=",
         "owner": "padok-team",
         "repo": "baywatch",
-        "rev": "598b26b9956b5f8a5aa0db13872dbe2077946367",
+        "rev": "1767c692b413632da0ec9624ea5459d84a302c63",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729027341,
-        "narHash": "sha256-IqWD7bA9iJVifvJlB4vs2KUXVhN+d9lECWdNB4jJ0tE=",
+        "lastModified": 1730016908,
+        "narHash": "sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2a4fd1cfd8ed5648583dadef86966a8231024221",
+        "rev": "e83414058edd339148dc142a8437edb9450574c8",
         "type": "github"
       },
       "original": {
@@ -127,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728790083,
-        "narHash": "sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y=",
+        "lastModified": 1729999765,
+        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "5c54c33aa04df5dd4b0984b7eb861d1981009b22",
+        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
         "type": "github"
       },
       "original": {
@@ -142,11 +142,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1728729581,
-        "narHash": "sha256-oazkQ/z7r43YkDLLQdMg8oIB3CwWNb+2ZrYOxtLEWTQ=",
+        "lastModified": 1730161780,
+        "narHash": "sha256-z5ILcmwMtiCoHTXS1KsQWqigO7HJO8sbyK7f7wn9F/E=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "a8dd1b21995964b115b1e3ec639dd6ce24ab9806",
+        "rev": "07d15e8990d5d86a631641b4c429bc0a7400cfb8",
         "type": "github"
       },
       "original": {
@@ -178,11 +178,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1729880355,
+        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
         "type": "github"
       },
       "original": {
@@ -226,11 +226,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1728156290,
-        "narHash": "sha256-uogSvuAp+1BYtdu6UWuObjHqSbBohpyARXDWqgI12Ss=",
+        "lastModified": 1729973466,
+        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17ae88b569bb15590549ff478bab6494dde4a907",
+        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
         "type": "github"
       },
       "original": {
@@ -273,11 +273,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1728778939,
-        "narHash": "sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe+8kX83snTNaFHE=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ff68f91754be6f3427e4986d7949e6273659be1d",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -310,11 +310,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1728345710,
-        "narHash": "sha256-lpunY1+bf90ts+sA2/FgxVNIegPDKCpEoWwOPu4ITTQ=",
+        "lastModified": 1729999681,
+        "narHash": "sha256-qm0uCtM9bg97LeJTKQ8dqV/FvqRN+ompyW4GIJruLuw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "06535d0e3d0201e6a8080dd32dbfde339b94f01b",
+        "rev": "1666d16426abe79af5c47b7c0efa82fd31bf4c56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'baywatch':
    'github:padok-team/baywatch/598b26b9956b5f8a5aa0db13872dbe2077946367?narHash=sha256-4fVameZ6v9OGRE/MaGUA7Y%2Bj0aFSDs4BjN92iqLFydI%3D' (2024-10-24)
  → 'github:padok-team/baywatch/1767c692b413632da0ec9624ea5459d84a302c63?narHash=sha256-dqjmlFJLeyatRNgHnxUXI%2BqF/gG0JKaNusK3ZxF6S00%3D' (2024-10-25)
• Updated input 'home-manager':
    'github:nix-community/home-manager/2a4fd1cfd8ed5648583dadef86966a8231024221?narHash=sha256-IqWD7bA9iJVifvJlB4vs2KUXVhN%2Bd9lECWdNB4jJ0tE%3D' (2024-10-15)
  → 'github:nix-community/home-manager/e83414058edd339148dc142a8437edb9450574c8?narHash=sha256-bFCxJco7d8IgmjfNExNz9knP8wvwbXU4s/d53KOK6U0%3D' (2024-10-27)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/5c54c33aa04df5dd4b0984b7eb861d1981009b22?narHash=sha256-grMdAd4KSU6uPqsfLzA1B/3pb9GtGI9o8qb0qFzEU/Y%3D' (2024-10-13)
  → 'github:nix-community/nix-index-database/0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f?narHash=sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX%2BY%3D' (2024-10-27)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/a8dd1b21995964b115b1e3ec639dd6ce24ab9806?narHash=sha256-oazkQ/z7r43YkDLLQdMg8oIB3CwWNb%2B2ZrYOxtLEWTQ%3D' (2024-10-12)
  → 'github:NixOS/nixos-hardware/07d15e8990d5d86a631641b4c429bc0a7400cfb8?narHash=sha256-z5ILcmwMtiCoHTXS1KsQWqigO7HJO8sbyK7f7wn9F/E%3D' (2024-10-29)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5633bcff0c6162b9e4b5f1264264611e950c8ec7?narHash=sha256-9UTxR8eukdg%2BXZeHgxW5hQA9fIKHsKCdOIUycTryeVw%3D' (2024-10-09)
  → 'github:nixos/nixpkgs/18536bf04cd71abd345f9579158841376fdd0c5a?narHash=sha256-RP%2BOQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM%3D' (2024-10-25)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/ff68f91754be6f3427e4986d7949e6273659be1d?narHash=sha256-WybK5E3hpGxtCYtBwpRj1E9JoiVxe%2B8kX83snTNaFHE%3D' (2024-10-13)
  → 'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6?narHash=sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ%2B/nVtALHIciX/BI%3D' (2024-10-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/06535d0e3d0201e6a8080dd32dbfde339b94f01b?narHash=sha256-lpunY1%2Bbf90ts%2BsA2/FgxVNIegPDKCpEoWwOPu4ITTQ%3D' (2024-10-08)
  → 'github:Mic92/sops-nix/1666d16426abe79af5c47b7c0efa82fd31bf4c56?narHash=sha256-qm0uCtM9bg97LeJTKQ8dqV/FvqRN%2BompyW4GIJruLuw%3D' (2024-10-27)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/17ae88b569bb15590549ff478bab6494dde4a907?narHash=sha256-uogSvuAp%2B1BYtdu6UWuObjHqSbBohpyARXDWqgI12Ss%3D' (2024-10-05)
  → 'github:NixOS/nixpkgs/cd3e8833d70618c4eea8df06f95b364b016d4950?narHash=sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk%3D' (2024-10-26)
```