### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -272,11 +272,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1729104314,
-        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
+        "lastModified": 1730302582,
+        "narHash": "sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
+        "rev": "af8a16fe5c264f5e9e18bcee2859b40a656876cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/3c3e88f0f544d6bb54329832616af7eb971b6be6?narHash=sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ%2B/nVtALHIciX/BI%3D' (2024-10-16)
  → 'github:cachix/git-hooks.nix/af8a16fe5c264f5e9e18bcee2859b40a656876cf?narHash=sha256-W1MIJpADXQCgosJZT8qBYLRuZls2KSiKdpnTVdKBuvU%3D' (2024-10-30)
```