### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729999765,
-        "narHash": "sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX+Y=",
+        "lastModified": 1730604744,
+        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f",
+        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730520317,
-        "narHash": "sha256-IH+vuP/F4zdOwmbCNXtszaCbzAiqx5O72NwtlTv+Nco=",
+        "lastModified": 1730537918,
+        "narHash": "sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d3986e78856a70d0b38d9e88dc39390556c2e962",
+        "rev": "f6e0cd5c47d150c4718199084e5764f968f1b560",
         "type": "github"
       },
       "original": {
@@ -224,11 +224,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1729973466,
-        "narHash": "sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk=",
+        "lastModified": 1730602179,
+        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cd3e8833d70618c4eea8df06f95b364b016d4950",
+        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
         "type": "github"
       },
       "original": {
@@ -308,11 +308,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1729999681,
-        "narHash": "sha256-qm0uCtM9bg97LeJTKQ8dqV/FvqRN+ompyW4GIJruLuw=",
+        "lastModified": 1730605784,
+        "narHash": "sha256-1NveNAMLHbxOg0BpBMSVuZ2yW2PpDnZLbZ25wV50PMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1666d16426abe79af5c47b7c0efa82fd31bf4c56",
+        "rev": "e9b5eef9b51cdf966c76143e13a9476725b2f760",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/0e3a8778c2ee218eff8de6aacf3d2fa6c33b2d4f?narHash=sha256-LYsavZXitFjjyETZoij8usXjTa7fa9AIF3Sk3MJSX%2BY%3D' (2024-10-27)
  → 'github:nix-community/nix-index-database/cc2ddbf2df8ef7cc933543b1b42b845ee4772318?narHash=sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4%3D' (2024-11-03)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d3986e78856a70d0b38d9e88dc39390556c2e962?narHash=sha256-IH%2BvuP/F4zdOwmbCNXtszaCbzAiqx5O72NwtlTv%2BNco%3D' (2024-11-02)
  → 'github:NixOS/nixos-hardware/f6e0cd5c47d150c4718199084e5764f968f1b560?narHash=sha256-GJB1/aaTnAtt9sso/EQ77TAGJ/rt6uvlP0RqZFnWue8%3D' (2024-11-02)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/1666d16426abe79af5c47b7c0efa82fd31bf4c56?narHash=sha256-qm0uCtM9bg97LeJTKQ8dqV/FvqRN%2BompyW4GIJruLuw%3D' (2024-10-27)
  → 'github:Mic92/sops-nix/e9b5eef9b51cdf966c76143e13a9476725b2f760?narHash=sha256-1NveNAMLHbxOg0BpBMSVuZ2yW2PpDnZLbZ25wV50PMc%3D' (2024-11-03)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/cd3e8833d70618c4eea8df06f95b364b016d4950?narHash=sha256-knnVBGfTCZlQgxY1SgH0vn2OyehH9ykfF8geZgS95bk%3D' (2024-10-26)
  → 'github:NixOS/nixpkgs/3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c?narHash=sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY%3D' (2024-11-03)
```