### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730828750,
-        "narHash": "sha256-XrnZLkLiBYNlwV5gus/8DT7nncF1TS5la6Be7rdVOpI=",
+        "lastModified": 1730919458,
+        "narHash": "sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2e78b1af8025108ecd6edaa3ab09695b8a4d3d55",
+        "rev": "e1cc1f6483393634aee94514186d21a4871e78d7",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730746162,
-        "narHash": "sha256-ZGmI+3AbT8NkDdBQujF+HIxZ+sWXuyT6X8B49etWY2g=",
+        "lastModified": 1730883027,
+        "narHash": "sha256-pvXMOJIqRW0trsW+FzRMl6d5PbsM4rWfD5lcKCOrrwI=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "59d6988329626132eaf107761643f55eb979eef1",
+        "rev": "c5ae1e214ff935f2d3593187a131becb289ea639",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/2e78b1af8025108ecd6edaa3ab09695b8a4d3d55?narHash=sha256-XrnZLkLiBYNlwV5gus/8DT7nncF1TS5la6Be7rdVOpI%3D' (2024-11-05)
  → 'github:NixOS/nixos-hardware/e1cc1f6483393634aee94514186d21a4871e78d7?narHash=sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg%3D' (2024-11-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/59d6988329626132eaf107761643f55eb979eef1?narHash=sha256-ZGmI%2B3AbT8NkDdBQujF%2BHIxZ%2BsWXuyT6X8B49etWY2g%3D' (2024-11-04)
  → 'github:Mic92/sops-nix/c5ae1e214ff935f2d3593187a131becb289ea639?narHash=sha256-pvXMOJIqRW0trsW%2BFzRMl6d5PbsM4rWfD5lcKCOrrwI%3D' (2024-11-06)
```