### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730215959,
-        "narHash": "sha256-YNYDLGRGyZ+d+PyHds8q3nTPaM0+HCDgY10vFBNYkR4=",
+        "lastModified": 1731003163,
+        "narHash": "sha256-j/eEXBw3QJmpPE3UY4wMdUJ4MA93KnY6fxXLs9QeFrI=",
         "owner": "padok-team",
         "repo": "baywatch",
-        "rev": "3a6002f4727f6f443650e53d113621963ae8fbbe",
+        "rev": "fba3ea3144fafeb9c73d256f0173425ea5bb19c1",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1730883027,
-        "narHash": "sha256-pvXMOJIqRW0trsW+FzRMl6d5PbsM4rWfD5lcKCOrrwI=",
+        "lastModified": 1731008979,
+        "narHash": "sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c5ae1e214ff935f2d3593187a131becb289ea639",
+        "rev": "fe63071416471abdab06caa234122932a7c4b980",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'baywatch':
    'github:padok-team/baywatch/3a6002f4727f6f443650e53d113621963ae8fbbe?narHash=sha256-YNYDLGRGyZ%2Bd%2BPyHds8q3nTPaM0%2BHCDgY10vFBNYkR4%3D' (2024-10-29)
  → 'github:padok-team/baywatch/fba3ea3144fafeb9c73d256f0173425ea5bb19c1?narHash=sha256-j/eEXBw3QJmpPE3UY4wMdUJ4MA93KnY6fxXLs9QeFrI%3D' (2024-11-07)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/c5ae1e214ff935f2d3593187a131becb289ea639?narHash=sha256-pvXMOJIqRW0trsW%2BFzRMl6d5PbsM4rWfD5lcKCOrrwI%3D' (2024-11-06)
  → 'github:Mic92/sops-nix/fe63071416471abdab06caa234122932a7c4b980?narHash=sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE%3D' (2024-11-07)
```