### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1731008979,
-        "narHash": "sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE=",
+        "lastModified": 1731047660,
+        "narHash": "sha256-iyp51lPWEQz4c5VH9bVbAuBcFP4crETU2QJYh5V0NYA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "fe63071416471abdab06caa234122932a7c4b980",
+        "rev": "60e1bce1999f126e3b16ef45f89f72f0c3f8d16f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'sops-nix':
    'github:Mic92/sops-nix/fe63071416471abdab06caa234122932a7c4b980?narHash=sha256-yN1NxvmqV8UltLkqYBWTeZNgpD/eyh/7LM58caHiEfE%3D' (2024-11-07)
  → 'github:Mic92/sops-nix/60e1bce1999f126e3b16ef45f89f72f0c3f8d16f?narHash=sha256-iyp51lPWEQz4c5VH9bVbAuBcFP4crETU2QJYh5V0NYA%3D' (2024-11-08)
```