### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730604744,
-        "narHash": "sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4=",
+        "lastModified": 1731209121,
+        "narHash": "sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "cc2ddbf2df8ef7cc933543b1b42b845ee4772318",
+        "rev": "896019f04b22ce5db4c0ee4f89978694f44345c3",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1730635861,
-        "narHash": "sha256-Npp3pl9aeAiq+wZPDbw2ZxybNuZWyuN7AY6fik56DCo=",
+        "lastModified": 1731193165,
+        "narHash": "sha256-pGF8L5g9QpkQtJP9JmNIRNZfcyhJHf7uT+d8tqI1h6Y=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "293668587937daae1df085ee36d2b2d0792b7a0f",
+        "rev": "f33173b9d22e554a6f869626bc01808d35995257",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/cc2ddbf2df8ef7cc933543b1b42b845ee4772318?narHash=sha256-/MK6QU4iOozJ4oHTfZipGtOgaT/uy/Jm4foCqHQeYR4%3D' (2024-11-03)
  → 'github:nix-community/nix-index-database/896019f04b22ce5db4c0ee4f89978694f44345c3?narHash=sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0%3D' (2024-11-10)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/293668587937daae1df085ee36d2b2d0792b7a0f?narHash=sha256-Npp3pl9aeAiq%2BwZPDbw2ZxybNuZWyuN7AY6fik56DCo%3D' (2024-11-03)
  → 'github:nix-community/plasma-manager/f33173b9d22e554a6f869626bc01808d35995257?narHash=sha256-pGF8L5g9QpkQtJP9JmNIRNZfcyhJHf7uT%2Bd8tqI1h6Y%3D' (2024-11-09)
```