### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1730919458,
-        "narHash": "sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg=",
+        "lastModified": 1731332224,
+        "narHash": "sha256-0ctfVp27ingWtY7dbP5+QpSQ98HaOZleU0teyHQUAw0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e1cc1f6483393634aee94514186d21a4871e78d7",
+        "rev": "184687ae1a3139faa4746168baf071f60d0310c8",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1730814269,
-        "narHash": "sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF+06nOg=",
+        "lastModified": 1731363552,
+        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d70155fdc00df4628446352fc58adc640cd705c2",
+        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1731213149,
-        "narHash": "sha256-jR8i6nFLmSmm0cIoeRQ8Q4EBARa3oGaAtEER/OMMxus=",
+        "lastModified": 1731364708,
+        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1675e3b0e1e663a4af49be67ecbc9e749f85eb7",
+        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e1cc1f6483393634aee94514186d21a4871e78d7?narHash=sha256-yMO0T0QJlmT/x4HEyvrCyigGrdYfIXX3e5gWqB64wLg%3D' (2024-11-06)
  → 'github:NixOS/nixos-hardware/184687ae1a3139faa4746168baf071f60d0310c8?narHash=sha256-0ctfVp27ingWtY7dbP5%2BQpSQ98HaOZleU0teyHQUAw0%3D' (2024-11-11)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/d70155fdc00df4628446352fc58adc640cd705c2?narHash=sha256-fWPHyhYE6xvMI1eGY3pwBTq85wcy1YXqdzTZF%2B06nOg%3D' (2024-11-05)
  → 'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0?narHash=sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf%2BInnSMT4jlMU%3D' (2024-11-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f1675e3b0e1e663a4af49be67ecbc9e749f85eb7?narHash=sha256-jR8i6nFLmSmm0cIoeRQ8Q4EBARa3oGaAtEER/OMMxus%3D' (2024-11-10)
  → 'github:Mic92/sops-nix/4c91d52db103e757fc25b58998b0576ae702d659?narHash=sha256-HC0anOL%2BKmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA%3D' (2024-11-11)
```