### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731235328,
-        "narHash": "sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs=",
+        "lastModified": 1731535640,
+        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "60bb110917844d354f3c18e05450606a435d2d10",
+        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/60bb110917844d354f3c18e05450606a435d2d10?narHash=sha256-NjavpgE9/bMe/ABvZpyHIUeYF1mqR5lhaep3wB79ucs%3D' (2024-11-10)
  → 'github:nix-community/home-manager/35b055009afd0107b69c286fca34d2ad98940d57?narHash=sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM%3D' (2024-11-13)
```