### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731535640,
-        "narHash": "sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM=",
+        "lastModified": 1731604581,
+        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35b055009afd0107b69c286fca34d2ad98940d57",
+        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731209121,
-        "narHash": "sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0=",
+        "lastModified": 1731593150,
+        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "896019f04b22ce5db4c0ee4f89978694f44345c3",
+        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731139594,
-        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
+        "lastModified": 1731319897,
+        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
+        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/35b055009afd0107b69c286fca34d2ad98940d57?narHash=sha256-2EckCJn4wxran/TsRiCOFcmVpep2m9EBKl99NBh2GnM%3D' (2024-11-13)
  → 'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10?narHash=sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM%3D' (2024-11-14)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/896019f04b22ce5db4c0ee4f89978694f44345c3?narHash=sha256-BF7FBh1hIYPDihdUlImHGsQzaJZVLLfYqfDx41wjuF0%3D' (2024-11-10)
  → 'github:nix-community/nix-index-database/40d882b55e89add1ded379cc99edaab24983d6d9?narHash=sha256-FvksinoI2Y6kuwH%2BcKBu1oDA8uPGfoRqgtQV6O8GDc4%3D' (2024-11-14)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/76612b17c0ce71689921ca12d9ffdc9c23ce40b2?narHash=sha256-IigrKK3vYRpUu%2BHEjPL/phrfh7Ox881er1UEsZvw9Q4%3D' (2024-11-09)
  → 'github:nixos/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c?narHash=sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY%2B/Z96ZcLpooIbuEI%3D' (2024-11-11)
```