### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731604581,
-        "narHash": "sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM=",
+        "lastModified": 1732303962,
+        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1d0862ee2d7c6f6cd720d6f32213fa425004be10",
+        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731593150,
-        "narHash": "sha256-FvksinoI2Y6kuwH+cKBu1oDA8uPGfoRqgtQV6O8GDc4=",
+        "lastModified": 1731814505,
+        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "40d882b55e89add1ded379cc99edaab24983d6d9",
+        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731403644,
-        "narHash": "sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI=",
+        "lastModified": 1731797098,
+        "narHash": "sha256-UhWmEZhwJZmVZ1jfHZFzCg+ZLO9Tb/v3Y6LC0UNyeTo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "f6581f1c3b137086e42a08a906bdada63045f991",
+        "rev": "672ac2ac86f7dff2f6f3406405bddecf960e0db6",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731319897,
-        "narHash": "sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY+/Z96ZcLpooIbuEI=",
+        "lastModified": 1732014248,
+        "narHash": "sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc460ec76cbff0e66e269457d7b728432263166c",
+        "rev": "23e89b7da85c3640bbc2173fe04f4bd114342367",
         "type": "github"
       },
       "original": {
@@ -202,22 +202,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-stable_2": {
-      "locked": {
-        "lastModified": 1730602179,
-        "narHash": "sha256-efgLzQAWSzJuCLiCaQUCDu4NudNlHdg2NzGLX5GYaEY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3c2f1c4ca372622cb2f9de8016c9a0b1cbd0f37c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -255,11 +239,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1731363552,
-        "narHash": "sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf+InnSMT4jlMU=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "cd1af27aa85026ac759d5d3fccf650abe7e1bbf0",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -287,15 +271,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable_2"
+        ]
       },
       "locked": {
-        "lastModified": 1731364708,
-        "narHash": "sha256-HC0anOL+KmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA=",
+        "lastModified": 1732186149,
+        "narHash": "sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c91d52db103e757fc25b58998b0576ae702d659",
+        "rev": "53c853fb1a7e4f25f68805ee25c83d5de18dc699",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1d0862ee2d7c6f6cd720d6f32213fa425004be10?narHash=sha256-Qq2YZZaDTB3FZLWU/Hgh1uuWlUBl3cMLGB99bm7rFUM%3D' (2024-11-14)
  → 'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c?narHash=sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg%2BFBQDsyAilu637g%3D' (2024-11-22)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/40d882b55e89add1ded379cc99edaab24983d6d9?narHash=sha256-FvksinoI2Y6kuwH%2BcKBu1oDA8uPGfoRqgtQV6O8GDc4%3D' (2024-11-14)
  → 'github:nix-community/nix-index-database/bdba246946fb079b87b4cada4df9b1cdf1c06132?narHash=sha256-l9ryrx1Twh08a%2BgxrMGM9O/aZKEimZfa6sZVyPCImgI%3D' (2024-11-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/f6581f1c3b137086e42a08a906bdada63045f991?narHash=sha256-T9V7CTucjRZ4Qc6pUEV/kpgNGzQbHWfGcfK6JJLfUeI%3D' (2024-11-12)
  → 'github:NixOS/nixos-hardware/672ac2ac86f7dff2f6f3406405bddecf960e0db6?narHash=sha256-UhWmEZhwJZmVZ1jfHZFzCg%2BZLO9Tb/v3Y6LC0UNyeTo%3D' (2024-11-16)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c?narHash=sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY%2B/Z96ZcLpooIbuEI%3D' (2024-11-11)
  → 'github:nixos/nixpkgs/23e89b7da85c3640bbc2173fe04f4bd114342367?narHash=sha256-y/MEyuJ5oBWrWAic/14LaIr/u5E0wRVzyYsouYY3W6w%3D' (2024-11-19)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/cd1af27aa85026ac759d5d3fccf650abe7e1bbf0?narHash=sha256-vFta1uHnD29VUY4HJOO/D6p6rxyObnf%2BInnSMT4jlMU%3D' (2024-11-11)
  → 'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c?narHash=sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE%3D' (2024-11-19)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/4c91d52db103e757fc25b58998b0576ae702d659?narHash=sha256-HC0anOL%2BKmUQ2hdRl0AtunbAckasxrkn4VLmxbW/WaA%3D' (2024-11-11)
  → 'github:Mic92/sops-nix/53c853fb1a7e4f25f68805ee25c83d5de18dc699?narHash=sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0%3D' (2024-11-21)
• Removed input 'sops-nix/nixpkgs-stable'
```