### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732303962,
-        "narHash": "sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg+FBQDsyAilu637g=",
+        "lastModified": 1732397793,
+        "narHash": "sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF+5mroU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cf9cb2ee78aa129e5b8220135a511a2be254c0c",
+        "rev": "92fef254a9071fa41a13908281284e6a62b9c92e",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731814505,
-        "narHash": "sha256-l9ryrx1Twh08a+gxrMGM9O/aZKEimZfa6sZVyPCImgI=",
+        "lastModified": 1732419467,
+        "narHash": "sha256-TjuKScXbj4Ddr0L+kEOLFaYOhzbS/k/EFL543wkjN5E=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bdba246946fb079b87b4cada4df9b1cdf1c06132",
+        "rev": "0ef970b7021e0ee9ab93437d0e28296e86669b03",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/8cf9cb2ee78aa129e5b8220135a511a2be254c0c?narHash=sha256-5Umjb5AdtxV5jSJd5jxoCckh5mlg%2BFBQDsyAilu637g%3D' (2024-11-22)
  → 'github:nix-community/home-manager/92fef254a9071fa41a13908281284e6a62b9c92e?narHash=sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF%2B5mroU%3D' (2024-11-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bdba246946fb079b87b4cada4df9b1cdf1c06132?narHash=sha256-l9ryrx1Twh08a%2BgxrMGM9O/aZKEimZfa6sZVyPCImgI%3D' (2024-11-17)
  → 'github:nix-community/nix-index-database/0ef970b7021e0ee9ab93437d0e28296e86669b03?narHash=sha256-TjuKScXbj4Ddr0L%2BkEOLFaYOhzbS/k/EFL543wkjN5E%3D' (2024-11-24)
```