### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732397793,
-        "narHash": "sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF+5mroU=",
+        "lastModified": 1732482255,
+        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "92fef254a9071fa41a13908281284e6a62b9c92e",
+        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732419467,
-        "narHash": "sha256-TjuKScXbj4Ddr0L+kEOLFaYOhzbS/k/EFL543wkjN5E=",
+        "lastModified": 1732461762,
+        "narHash": "sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "0ef970b7021e0ee9ab93437d0e28296e86669b03",
+        "rev": "bedc30c64442579943c1c6e7579db263d810884f",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1731797098,
-        "narHash": "sha256-UhWmEZhwJZmVZ1jfHZFzCg+ZLO9Tb/v3Y6LC0UNyeTo=",
+        "lastModified": 1732483221,
+        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "672ac2ac86f7dff2f6f3406405bddecf960e0db6",
+        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731193165,
-        "narHash": "sha256-pGF8L5g9QpkQtJP9JmNIRNZfcyhJHf7uT+d8tqI1h6Y=",
+        "lastModified": 1732465698,
+        "narHash": "sha256-xiue+Kj2Jm8PwyZQcHl4CaYmMIgo5oi37hVHqiw2Unk=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "f33173b9d22e554a6f869626bc01808d35995257",
+        "rev": "16d65cd02b5de665d1bcfec1616c02c71a1014a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/92fef254a9071fa41a13908281284e6a62b9c92e?narHash=sha256-2jaf/zkug22hzlldm1PKdKJLVKgdjVXbf47SF%2B5mroU%3D' (2024-11-23)
  → 'github:nix-community/home-manager/a9953635d7f34e7358d5189751110f87e3ac17da?narHash=sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A%3D' (2024-11-24)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/0ef970b7021e0ee9ab93437d0e28296e86669b03?narHash=sha256-TjuKScXbj4Ddr0L%2BkEOLFaYOhzbS/k/EFL543wkjN5E%3D' (2024-11-24)
  → 'github:nix-community/nix-index-database/bedc30c64442579943c1c6e7579db263d810884f?narHash=sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0%3D' (2024-11-24)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/672ac2ac86f7dff2f6f3406405bddecf960e0db6?narHash=sha256-UhWmEZhwJZmVZ1jfHZFzCg%2BZLO9Tb/v3Y6LC0UNyeTo%3D' (2024-11-16)
  → 'github:NixOS/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405?narHash=sha256-kF6rDeCshoCgmQz%2B7uiuPdREVFuzhIorGOoPXMalL2U%3D' (2024-11-24)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/f33173b9d22e554a6f869626bc01808d35995257?narHash=sha256-pGF8L5g9QpkQtJP9JmNIRNZfcyhJHf7uT%2Bd8tqI1h6Y%3D' (2024-11-09)
  → 'github:nix-community/plasma-manager/16d65cd02b5de665d1bcfec1616c02c71a1014a6?narHash=sha256-xiue%2BKj2Jm8PwyZQcHl4CaYmMIgo5oi37hVHqiw2Unk%3D' (2024-11-24)
```