### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732461762,
-        "narHash": "sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0=",
+        "lastModified": 1732519917,
+        "narHash": "sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "bedc30c64442579943c1c6e7579db263d810884f",
+        "rev": "f4a5ca5771ba9ca31ad24a62c8d511a405303436",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732186149,
-        "narHash": "sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0=",
+        "lastModified": 1732575825,
+        "narHash": "sha256-xtt95+c7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "53c853fb1a7e4f25f68805ee25c83d5de18dc699",
+        "rev": "3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/bedc30c64442579943c1c6e7579db263d810884f?narHash=sha256-3SMxtkXlmzPmF4NXCt6lLF2IkdyAmO824PlScUKVhB0%3D' (2024-11-24)
  → 'github:nix-community/nix-index-database/f4a5ca5771ba9ca31ad24a62c8d511a405303436?narHash=sha256-AGXhwHdJV0q/WNgqwrR2zriubLr785b02FphaBtyt1Q%3D' (2024-11-25)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/53c853fb1a7e4f25f68805ee25c83d5de18dc699?narHash=sha256-N9JGWe/T8BC0Tss2Cv30plvZUYoiRmykP7ZdY2on2b0%3D' (2024-11-21)
  → 'github:Mic92/sops-nix/3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa?narHash=sha256-xtt95%2Bc7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk%3D' (2024-11-25)
```