### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732482255,
-        "narHash": "sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A=",
+        "lastModified": 1732793095,
+        "narHash": "sha256-6TrknJ8CpvSSF4gviQSeD+wyj3siRcMvdBKhOXkEMKU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9953635d7f34e7358d5189751110f87e3ac17da",
+        "rev": "2f7739d01080feb4549524e8f6927669b61c6ee3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/a9953635d7f34e7358d5189751110f87e3ac17da?narHash=sha256-GUffLwzawz5WRVfWaWCg78n/HrBJrOG7QadFY6rtV8A%3D' (2024-11-24)
  → 'github:nix-community/home-manager/2f7739d01080feb4549524e8f6927669b61c6ee3?narHash=sha256-6TrknJ8CpvSSF4gviQSeD%2Bwyj3siRcMvdBKhOXkEMKU%3D' (2024-11-28)
```