### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732793095,
-        "narHash": "sha256-6TrknJ8CpvSSF4gviQSeD+wyj3siRcMvdBKhOXkEMKU=",
+        "lastModified": 1732884235,
+        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2f7739d01080feb4549524e8f6927669b61c6ee3",
+        "rev": "819f682269f4e002884702b87e445c82840c68f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/2f7739d01080feb4549524e8f6927669b61c6ee3?narHash=sha256-6TrknJ8CpvSSF4gviQSeD%2Bwyj3siRcMvdBKhOXkEMKU%3D' (2024-11-28)
  → 'github:nix-community/home-manager/819f682269f4e002884702b87e445c82840c68f2?narHash=sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB%2BXG6Q%3D' (2024-11-29)
```