### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732884235,
-        "narHash": "sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB+XG6Q=",
+        "lastModified": 1733085484,
+        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "819f682269f4e002884702b87e445c82840c68f2",
+        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1732483221,
-        "narHash": "sha256-kF6rDeCshoCgmQz+7uiuPdREVFuzhIorGOoPXMalL2U=",
+        "lastModified": 1733066523,
+        "narHash": "sha256-aQorWITXZu7b095UwnpUvcGt9dNJie/GO9r4hZfe2sU=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "45348ad6fb8ac0e8415f6e5e96efe47dd7f39405",
+        "rev": "fe01780d356d70fd119a19277bff71d3e78dad00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/819f682269f4e002884702b87e445c82840c68f2?narHash=sha256-r8j6R3nrvwbT1aUp4EPQ1KC7gm0pu9VcV1aNaB%2BXG6Q%3D' (2024-11-29)
  → 'github:nix-community/home-manager/c1fee8d4a60b89cae12b288ba9dbc608ff298163?narHash=sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ%2BGN0r8%3D' (2024-12-01)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/45348ad6fb8ac0e8415f6e5e96efe47dd7f39405?narHash=sha256-kF6rDeCshoCgmQz%2B7uiuPdREVFuzhIorGOoPXMalL2U%3D' (2024-11-24)
  → 'github:NixOS/nixos-hardware/fe01780d356d70fd119a19277bff71d3e78dad00?narHash=sha256-aQorWITXZu7b095UwnpUvcGt9dNJie/GO9r4hZfe2sU%3D' (2024-12-01)
```