### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733085484,
-        "narHash": "sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ+GN0r8=",
+        "lastModified": 1733175814,
+        "narHash": "sha256-zFOtOaqjzZfPMsm1mwu98syv3y+jziAq5DfWygaMtLg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c1fee8d4a60b89cae12b288ba9dbc608ff298163",
+        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727884248,
-        "narHash": "sha256-2BNKYcgwvf8Y82COp5hKA29GqEgNEkebxeiqNWzMx28=",
+        "lastModified": 1733156752,
+        "narHash": "sha256-zTQNU0u0eF+B7HeYAIQI3KQj8Jwd6dZ0AG1KsjEOXkA=",
         "owner": "kolide",
         "repo": "nix-agent",
-        "rev": "3eefae85fad746c7da3cc9e250fc320b15e0c722",
+        "rev": "d154b67a88e9cf8a6c10fd589afd51b299f7faca",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733066523,
-        "narHash": "sha256-aQorWITXZu7b095UwnpUvcGt9dNJie/GO9r4hZfe2sU=",
+        "lastModified": 1733139194,
+        "narHash": "sha256-PVQW9ovo0CJbhuhCsrhFJGGdD1euwUornspKpBIgdok=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "fe01780d356d70fd119a19277bff71d3e78dad00",
+        "rev": "c6c90887f84c02ce9ebf33b95ca79ef45007bf88",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732837521,
-        "narHash": "sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE=",
+        "lastModified": 1733015953,
+        "narHash": "sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE+crk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "970e93b9f82e2a0f3675757eb0bfc73297cc6370",
+        "rev": "ac35b104800bff9028425fec3b6e8a41de2bbfff",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732575825,
-        "narHash": "sha256-xtt95+c7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk=",
+        "lastModified": 1733128155,
+        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa",
+        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/c1fee8d4a60b89cae12b288ba9dbc608ff298163?narHash=sha256-dVmNuUajnU18oHzBQWZm1BQtANCHaqNuxTHZQ%2BGN0r8%3D' (2024-12-01)
  → 'github:nix-community/home-manager/bf23fe41082aa0289c209169302afd3397092f22?narHash=sha256-zFOtOaqjzZfPMsm1mwu98syv3y%2BjziAq5DfWygaMtLg%3D' (2024-12-02)
• Updated input 'kolide-launcher':
    'github:kolide/nix-agent/3eefae85fad746c7da3cc9e250fc320b15e0c722?narHash=sha256-2BNKYcgwvf8Y82COp5hKA29GqEgNEkebxeiqNWzMx28%3D' (2024-10-02)
  → 'github:kolide/nix-agent/d154b67a88e9cf8a6c10fd589afd51b299f7faca?narHash=sha256-zTQNU0u0eF%2BB7HeYAIQI3KQj8Jwd6dZ0AG1KsjEOXkA%3D' (2024-12-02)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/fe01780d356d70fd119a19277bff71d3e78dad00?narHash=sha256-aQorWITXZu7b095UwnpUvcGt9dNJie/GO9r4hZfe2sU%3D' (2024-12-01)
  → 'github:NixOS/nixos-hardware/c6c90887f84c02ce9ebf33b95ca79ef45007bf88?narHash=sha256-PVQW9ovo0CJbhuhCsrhFJGGdD1euwUornspKpBIgdok%3D' (2024-12-02)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/970e93b9f82e2a0f3675757eb0bfc73297cc6370?narHash=sha256-jNRNr49UiuIwaarqijgdTR2qLPifxsVhlJrKzQ8XUIE%3D' (2024-11-28)
  → 'github:nixos/nixpkgs/ac35b104800bff9028425fec3b6e8a41de2bbfff?narHash=sha256-t4BBVpwG9B4hLgc6GUBuj3cjU7lP/PJfpTHuSqE%2Bcrk%3D' (2024-12-01)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/3433ea14fbd9e6671d0ff0dd45ed15ee4c156ffa?narHash=sha256-xtt95%2Bc7OUMoqZf4OvA/7AemiH3aVuWHQbErYQoPwFk%3D' (2024-11-25)
  → 'github:Mic92/sops-nix/c6134b6fff6bda95a1ac872a2a9d5f32e3c37856?narHash=sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc%3D' (2024-12-02)
```