### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733175814,
-        "narHash": "sha256-zFOtOaqjzZfPMsm1mwu98syv3y+jziAq5DfWygaMtLg=",
+        "lastModified": 1733354384,
+        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "bf23fe41082aa0289c209169302afd3397092f22",
+        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1732021966,
-        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
+        "lastModified": 1733318908,
+        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
+        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/bf23fe41082aa0289c209169302afd3397092f22?narHash=sha256-zFOtOaqjzZfPMsm1mwu98syv3y%2BjziAq5DfWygaMtLg%3D' (2024-12-02)
  → 'github:nix-community/home-manager/0daaded612b0e6eaed0a63fc9d0778d8f05940fe?narHash=sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM%3D' (2024-12-04)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/3308484d1a443fc5bc92012435d79e80458fe43c?narHash=sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE%3D' (2024-11-19)
  → 'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6?narHash=sha256-SVQVsbafSM1dJ4fpgyBqLZ%2BLft%2BjcQuMtEL3lQWx2Sk%3D' (2024-12-04)
```