### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733354384,
-        "narHash": "sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM=",
+        "lastModified": 1733389730,
+        "narHash": "sha256-KZMu4ddMll5khS0rYkJsVD0hVqjMNHlhTM3PCQar0Ag=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0daaded612b0e6eaed0a63fc9d0778d8f05940fe",
+        "rev": "65912bc6841cf420eb8c0a20e03df7cbbff5963f",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733005589,
-        "narHash": "sha256-NAym0oWYwKgFuAif6Z7HacU6Su/SJNTW4wEYC5urSYU=",
+        "lastModified": 1733410572,
+        "narHash": "sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "88ca377ff58b5c30a2879745829842554d4b21d5",
+        "rev": "92721d7402526599366d00e242813798e9914970",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/0daaded612b0e6eaed0a63fc9d0778d8f05940fe?narHash=sha256-foZG2PLwumxYZkpXq7ajHDhuQlXaUeKfOpFfQpMviLM%3D' (2024-12-04)
  → 'github:nix-community/home-manager/65912bc6841cf420eb8c0a20e03df7cbbff5963f?narHash=sha256-KZMu4ddMll5khS0rYkJsVD0hVqjMNHlhTM3PCQar0Ag%3D' (2024-12-05)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/88ca377ff58b5c30a2879745829842554d4b21d5?narHash=sha256-NAym0oWYwKgFuAif6Z7HacU6Su/SJNTW4wEYC5urSYU%3D' (2024-11-30)
  → 'github:nix-community/plasma-manager/92721d7402526599366d00e242813798e9914970?narHash=sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E%3D' (2024-12-05)
```