### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733024876,
-        "narHash": "sha256-vy9Q41hBE7Zg0yakF79neVgb3i3PQMSMR7uHPpPywFE=",
+        "lastModified": 1733629314,
+        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "6e0b7f81367069589a480b91603a10bcf71f3103",
+        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733410572,
+        "lastModified": 1733578387,
         "narHash": "sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "92721d7402526599366d00e242813798e9914970",
+        "rev": "2a64e173f1effdcc86e25cba0601e8feedf89115",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/6e0b7f81367069589a480b91603a10bcf71f3103?narHash=sha256-vy9Q41hBE7Zg0yakF79neVgb3i3PQMSMR7uHPpPywFE%3D' (2024-12-01)
  → 'github:nix-community/nix-index-database/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8?narHash=sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU%3D' (2024-12-08)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/92721d7402526599366d00e242813798e9914970?narHash=sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E%3D' (2024-12-05)
  → 'github:nix-community/plasma-manager/2a64e173f1effdcc86e25cba0601e8feedf89115?narHash=sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E%3D' (2024-12-07)
```