### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733392399,
-        "narHash": "sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG+cBns=",
+        "lastModified": 1733581040,
+        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d0797a04b81caeae77bcff10a9dde78bc17f5661",
+        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733318908,
-        "narHash": "sha256-SVQVsbafSM1dJ4fpgyBqLZ+Lft+jcQuMtEL3lQWx2Sk=",
+        "lastModified": 1733665616,
+        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "6f4e2a2112050951a314d2733a994fbab94864c6",
+        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d0797a04b81caeae77bcff10a9dde78bc17f5661?narHash=sha256-kEsTJTUQfQFIJOcLYFt/RvNxIK653ZkTBIs4DG%2BcBns%3D' (2024-12-05)
  → 'github:nixos/nixpkgs/22c3f2cf41a0e70184334a958e6b124fb0ce3e01?narHash=sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY%3D' (2024-12-07)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/6f4e2a2112050951a314d2733a994fbab94864c6?narHash=sha256-SVQVsbafSM1dJ4fpgyBqLZ%2BLft%2BjcQuMtEL3lQWx2Sk%3D' (2024-12-04)
  → 'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a?narHash=sha256-%2BXTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd%2Blh2A%3D' (2024-12-08)
```