### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733484277,
-        "narHash": "sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc=",
+        "lastModified": 1733754861,
+        "narHash": "sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a",
+        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733128155,
-        "narHash": "sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc=",
+        "lastModified": 1733785344,
+        "narHash": "sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee+HzNk+SQE=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c6134b6fff6bda95a1ac872a2a9d5f32e3c37856",
+        "rev": "a80af8929781b5fe92ddb8ae52e9027fae780d2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d00c6f6d0ad16d598bf7e2956f52c1d9d5de3c3a?narHash=sha256-i5ay20XsvpW91N4URET/nOc0VQWOAd4c4vbqYtcH8Rc%3D' (2024-12-06)
  → 'github:nix-community/home-manager/9ebaa80a227eaca9c87c53ed515ade013bc2bca9?narHash=sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY%3D' (2024-12-09)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/c6134b6fff6bda95a1ac872a2a9d5f32e3c37856?narHash=sha256-m6/qwJAJYcidGMEdLqjKzRIjapK4nUfMq7rDCTmZajc%3D' (2024-12-02)
  → 'github:Mic92/sops-nix/a80af8929781b5fe92ddb8ae52e9027fae780d2a?narHash=sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee%2BHzNk%2BSQE%3D' (2024-12-09)
```