### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733754861,
-        "narHash": "sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY=",
+        "lastModified": 1733873195,
+        "narHash": "sha256-dTosiZ3sZ/NKoLKQ++v8nZdEHya0eTNEsaizNp+MUPM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9ebaa80a227eaca9c87c53ed515ade013bc2bca9",
+        "rev": "f26aa4b76fb7606127032d33ac73d7d507d82758",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1733481457,
-        "narHash": "sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is=",
+        "lastModified": 1733861262,
+        "narHash": "sha256-+jjPup/ByS0LEVIrBbt7FnGugJgLeG9oc+ivFASYn2U=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e563803af3526852b6b1d77107a81908c66a9fcf",
+        "rev": "cf737e2eba82b603f54f71b10cb8fd09d22ce3f5",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731518532,
-        "narHash": "sha256-0u8D677YoSzRpeWyH6NZ1g44AoV8TyTXjI9w/wzKC04=",
+        "lastModified": 1733859160,
+        "narHash": "sha256-+zouljO+7IeyDOZo4I8xGe2oEqK+7IuHJNrj3YL3nWI=",
         "owner": "cterence",
         "repo": "nixos-work-config",
-        "rev": "cf02d99bab148b2ae47dd8c8bbc7557e9a41e4b0",
+        "rev": "6daed64b3547303b16464742ebdbcc94fff5e7ec",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "lastModified": 1733759999,
+        "narHash": "sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "a73246e2eef4c6ed172979932bc80e1404ba2d56",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733578387,
-        "narHash": "sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E=",
+        "lastModified": 1733858086,
+        "narHash": "sha256-h2BDIDKiqgMpA6E+mu0RgMGy3FeM6k+EuJ9xgOQ1+zw=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "2a64e173f1effdcc86e25cba0601e8feedf89115",
+        "rev": "7e2010249529931a3848054d5ff0dbf24675ab68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/9ebaa80a227eaca9c87c53ed515ade013bc2bca9?narHash=sha256-3JKzIou54yjiMVmvgdJwopekEvZxX3JDT8DpKZs4oXY%3D' (2024-12-09)
  → 'github:nix-community/home-manager/f26aa4b76fb7606127032d33ac73d7d507d82758?narHash=sha256-dTosiZ3sZ/NKoLKQ%2B%2Bv8nZdEHya0eTNEsaizNp%2BMUPM%3D' (2024-12-10)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e563803af3526852b6b1d77107a81908c66a9fcf?narHash=sha256-IS3bxa4N1VMSh3/P6vhEAHQZecQ3oAlKCDvzCQSO5Is%3D' (2024-12-06)
  → 'github:NixOS/nixos-hardware/cf737e2eba82b603f54f71b10cb8fd09d22ce3f5?narHash=sha256-%2BjjPup/ByS0LEVIrBbt7FnGugJgLeG9oc%2BivFASYn2U%3D' (2024-12-10)
• Updated input 'nixos-work-config':
    'github:cterence/nixos-work-config/cf02d99bab148b2ae47dd8c8bbc7557e9a41e4b0?narHash=sha256-0u8D677YoSzRpeWyH6NZ1g44AoV8TyTXjI9w/wzKC04%3D' (2024-11-13)
  → 'github:cterence/nixos-work-config/6daed64b3547303b16464742ebdbcc94fff5e7ec?narHash=sha256-%2BzouljO%2B7IeyDOZo4I8xGe2oEqK%2B7IuHJNrj3YL3nWI%3D' (2024-12-10)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/22c3f2cf41a0e70184334a958e6b124fb0ce3e01?narHash=sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY%3D' (2024-12-07)
  → 'github:nixos/nixpkgs/a73246e2eef4c6ed172979932bc80e1404ba2d56?narHash=sha256-463SNPWmz46iLzJKRzO3Q2b0Aurff3U1n0nYItxq7jU%3D' (2024-12-09)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/2a64e173f1effdcc86e25cba0601e8feedf89115?narHash=sha256-XkMZGeqg0GCRoSXvMcaHP7bdvWPRZxCK1sw1ASsc16E%3D' (2024-12-07)
  → 'github:nix-community/plasma-manager/7e2010249529931a3848054d5ff0dbf24675ab68?narHash=sha256-h2BDIDKiqgMpA6E%2Bmu0RgMGy3FeM6k%2BEuJ9xgOQ1%2Bzw%3D' (2024-12-10)
```