### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1731406904,
-        "narHash": "sha256-2wv+ejK2CK9Rfi7Gc5ozDYldA6IdKVqUxfGg5abIqYs=",
+        "lastModified": 1733901357,
+        "narHash": "sha256-suDp2/Z8OwgGD5oQXXInaNaDKZvv3oh8dn17QdvXF0c=",
         "owner": "padok-team",
         "repo": "baywatch",
-        "rev": "2280124ba867f5cf6828a1101650a4bc0a5e3cd9",
+        "rev": "d0a4881e17771cc86b6cf6b55da9d702acafeda4",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733873195,
-        "narHash": "sha256-dTosiZ3sZ/NKoLKQ++v8nZdEHya0eTNEsaizNp+MUPM=",
+        "lastModified": 1733951607,
+        "narHash": "sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n+aJkRzWj8PXwQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f26aa4b76fb7606127032d33ac73d7d507d82758",
+        "rev": "6e5b2d9e8014b5572e3367937a329e7053458d34",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733785344,
-        "narHash": "sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee+HzNk+SQE=",
+        "lastModified": 1733965552,
+        "narHash": "sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a80af8929781b5fe92ddb8ae52e9027fae780d2a",
+        "rev": "2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'baywatch':
    'github:padok-team/baywatch/2280124ba867f5cf6828a1101650a4bc0a5e3cd9?narHash=sha256-2wv%2BejK2CK9Rfi7Gc5ozDYldA6IdKVqUxfGg5abIqYs%3D' (2024-11-12)
  → 'github:padok-team/baywatch/d0a4881e17771cc86b6cf6b55da9d702acafeda4?narHash=sha256-suDp2/Z8OwgGD5oQXXInaNaDKZvv3oh8dn17QdvXF0c%3D' (2024-12-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/f26aa4b76fb7606127032d33ac73d7d507d82758?narHash=sha256-dTosiZ3sZ/NKoLKQ%2B%2Bv8nZdEHya0eTNEsaizNp%2BMUPM%3D' (2024-12-10)
  → 'github:nix-community/home-manager/6e5b2d9e8014b5572e3367937a329e7053458d34?narHash=sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n%2BaJkRzWj8PXwQ%3D' (2024-12-11)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/a80af8929781b5fe92ddb8ae52e9027fae780d2a?narHash=sha256-pm4cfEcPXripE36PYCl0A2Tu5ruwHEvTee%2BHzNk%2BSQE%3D' (2024-12-09)
  → 'github:Mic92/sops-nix/2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004?narHash=sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs%3D' (2024-12-12)
```