### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733951607,
-        "narHash": "sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n+aJkRzWj8PXwQ=",
+        "lastModified": 1734043726,
+        "narHash": "sha256-e9YAMReFV1fDPcZLFC2pa4k/8TloSXeX0z2VysNMAoA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6e5b2d9e8014b5572e3367937a329e7053458d34",
+        "rev": "3066cc58f552421a2c5414e78407fa5603405b1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6e5b2d9e8014b5572e3367937a329e7053458d34?narHash=sha256-CN6q6iCzxI1gkNyk4xLdwaMKi10r7n%2BaJkRzWj8PXwQ%3D' (2024-12-11)
  → 'github:nix-community/home-manager/3066cc58f552421a2c5414e78407fa5603405b1e?narHash=sha256-e9YAMReFV1fDPcZLFC2pa4k/8TloSXeX0z2VysNMAoA%3D' (2024-12-12)
```