### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733629314,
-        "narHash": "sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU=",
+        "lastModified": 1734234111,
+        "narHash": "sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f1e477a7dd11e27e7f98b646349cd66bbabf2fb8",
+        "rev": "311d6cf3ad3f56cb051ffab1f480b2909b3f754d",
         "type": "github"
       },
       "original": {
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1733665616,
-        "narHash": "sha256-+XTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd+lh2A=",
+        "lastModified": 1734190932,
+        "narHash": "sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "d8c02f0ffef0ef39f6063731fc539d8c71eb463a",
+        "rev": "c2b3567b03baf0999a1dd14f7e7ab34b46297d68",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/f1e477a7dd11e27e7f98b646349cd66bbabf2fb8?narHash=sha256-U0vivjQFAwjNDYt49Krevs1murX9hKBFe2Ye0cHpgbU%3D' (2024-12-08)
  → 'github:nix-community/nix-index-database/311d6cf3ad3f56cb051ffab1f480b2909b3f754d?narHash=sha256-icEMqBt4HtGH52PU5FHidgBrNJvOfXH6VQKNtnD1aw8%3D' (2024-12-15)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/d8c02f0ffef0ef39f6063731fc539d8c71eb463a?narHash=sha256-%2BXTFXYlFJBxohhMGLDpYdEnhUNdxN8dyTA8WAd%2Blh2A%3D' (2024-12-08)
  → 'github:cachix/git-hooks.nix/c2b3567b03baf0999a1dd14f7e7ab34b46297d68?narHash=sha256-nIweyhgHbDMJSH6zlciTe2abEzDKWkW28B6/qM9UWOU%3D' (2024-12-14)
```