### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -255,11 +255,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1734379367,
-        "narHash": "sha256-Keu8z5VgT5gnCF4pmB+g7XZFftHpfl4qOn7nqBcywdE=",
+        "lastModified": 1734425854,
+        "narHash": "sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99",
+        "rev": "0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/0bb4be58f21ff38fc3cdbd6c778eb67db97f0b99?narHash=sha256-Keu8z5VgT5gnCF4pmB%2Bg7XZFftHpfl4qOn7nqBcywdE%3D' (2024-12-16)
  → 'github:cachix/git-hooks.nix/0ddd26d0925f618c3a5d85a4fa5eb1e23a09491d?narHash=sha256-nzE5UbJ41aPEKf8R2ZFYtLkqPmF7EIUbNEdHMBLg0Ig%3D' (2024-12-17)
```