### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1734424634,
+        "narHash": "sha256-cHar1vqHOOyC7f1+tVycPoWTfKIaqkoe1Q6TnKzuti4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "d3c42f187194c26d9f0309a8ecc469d6c878ce33",
         "type": "github"
       },
       "original": {
@@ -291,11 +291,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733965552,
-        "narHash": "sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs=",
+        "lastModified": 1734546875,
+        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004",
+        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/3566ab7246670a43abd2ffa913cc62dad9cdf7d5?narHash=sha256-AKU6qqskl0yf2%2BJdRdD0cfxX4b9x3KKV5RqA6wijmPM%3D' (2024-12-13)
  → 'github:nixos/nixpkgs/d3c42f187194c26d9f0309a8ecc469d6c878ce33?narHash=sha256-cHar1vqHOOyC7f1%2BtVycPoWTfKIaqkoe1Q6TnKzuti4%3D' (2024-12-17)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/2d73fc6ac4eba4b9a83d3cb8275096fbb7ab4004?narHash=sha256-GZ4YtqkfyTjJFVCub5yAFWsHknG1nS/zfk7MuHht4Fs%3D' (2024-12-12)
  → 'github:Mic92/sops-nix/ed091321f4dd88afc28b5b4456e0a15bd8374b4d?narHash=sha256-6OvJbqQ6qPpNw3CA%2BW8Myo5aaLhIJY/nNFDk3zMXLfM%3D' (2024-12-18)
```