### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734821669,
-        "narHash": "sha256-F7Z2tIJsUEhErpK0sGMep4xG/eTVuK2eBpvgh3cS2H8=",
+        "lastModified": 1734893686,
+        "narHash": "sha256-JUEZn9MmpLGsW4J3luSX+R4BhcThccYpYg5AuKW7zG0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "51160a097a850839b7eae7ef08d0d3e7e353dfc3",
+        "rev": "edb8b00e4d17b2116b60eca50f38ac68f12b9ab4",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734352517,
-        "narHash": "sha256-mfv+J/vO4nqmIOlq8Y1rRW8hVsGH3M+I2ESMjhuebDs=",
+        "lastModified": 1734862644,
+        "narHash": "sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b12e314726a4226298fe82776b4baeaa7bcf3dcd",
+        "rev": "e8516a23524cc9083f5a02a8d64d14770e4c7c09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/51160a097a850839b7eae7ef08d0d3e7e353dfc3?narHash=sha256-F7Z2tIJsUEhErpK0sGMep4xG/eTVuK2eBpvgh3cS2H8%3D' (2024-12-21)
  → 'github:nix-community/home-manager/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4?narHash=sha256-JUEZn9MmpLGsW4J3luSX%2BR4BhcThccYpYg5AuKW7zG0%3D' (2024-12-22)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b12e314726a4226298fe82776b4baeaa7bcf3dcd?narHash=sha256-mfv%2BJ/vO4nqmIOlq8Y1rRW8hVsGH3M%2BI2ESMjhuebDs%3D' (2024-12-16)
  → 'github:NixOS/nixos-hardware/e8516a23524cc9083f5a02a8d64d14770e4c7c09?narHash=sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw%3D' (2024-12-22)
```