### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734893686,
-        "narHash": "sha256-JUEZn9MmpLGsW4J3luSX+R4BhcThccYpYg5AuKW7zG0=",
+        "lastModified": 1734992499,
+        "narHash": "sha256-f9UyHMTb+BwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "edb8b00e4d17b2116b60eca50f38ac68f12b9ab4",
+        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734862644,
-        "narHash": "sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw=",
+        "lastModified": 1734954597,
+        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "e8516a23524cc9083f5a02a8d64d14770e4c7c09",
+        "rev": "def1d472c832d77885f174089b0d34854b007198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/edb8b00e4d17b2116b60eca50f38ac68f12b9ab4?narHash=sha256-JUEZn9MmpLGsW4J3luSX%2BR4BhcThccYpYg5AuKW7zG0%3D' (2024-12-22)
  → 'github:nix-community/home-manager/f1b1786ea77739dcd181b920d430e30fb1608b8a?narHash=sha256-f9UyHMTb%2BBwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk%3D' (2024-12-23)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/e8516a23524cc9083f5a02a8d64d14770e4c7c09?narHash=sha256-04xesW7HITdF5WUmNM39WD4tkEERk3Ez2W1nNvdIvIw%3D' (2024-12-22)
  → 'github:NixOS/nixos-hardware/def1d472c832d77885f174089b0d34854b007198?narHash=sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl%2Bfk%3D' (2024-12-23)
```