### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734992499,
-        "narHash": "sha256-f9UyHMTb+BwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk=",
+        "lastModified": 1735053786,
+        "narHash": "sha256-Gm+0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f1b1786ea77739dcd181b920d430e30fb1608b8a",
+        "rev": "35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733858086,
-        "narHash": "sha256-h2BDIDKiqgMpA6E+mu0RgMGy3FeM6k+EuJ9xgOQ1+zw=",
+        "lastModified": 1735049224,
+        "narHash": "sha256-fWUd9kyXdepphJ7cCzOsuSo7l0kbFCkUqfgKqZyFZzE=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "7e2010249529931a3848054d5ff0dbf24675ab68",
+        "rev": "d16bbded0ae452bc088489e7dca3ef58d8d1830b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f1b1786ea77739dcd181b920d430e30fb1608b8a?narHash=sha256-f9UyHMTb%2BBwF6RDZ8eO9HOkSlKeeSPBlcYhMmV1UNIk%3D' (2024-12-23)
  → 'github:nix-community/home-manager/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84?narHash=sha256-Gm%2B0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw%3D' (2024-12-24)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/7e2010249529931a3848054d5ff0dbf24675ab68?narHash=sha256-h2BDIDKiqgMpA6E%2Bmu0RgMGy3FeM6k%2BEuJ9xgOQ1%2Bzw%3D' (2024-12-10)
  → 'github:nix-community/plasma-manager/d16bbded0ae452bc088489e7dca3ef58d8d1830b?narHash=sha256-fWUd9kyXdepphJ7cCzOsuSo7l0kbFCkUqfgKqZyFZzE%3D' (2024-12-24)
```