### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1732283103,
-        "narHash": "sha256-QoOWFxVB0xcjpOfODNKYAkWSvYchnopHcVeJOcnBgDQ=",
+        "lastModified": 1732283434,
+        "narHash": "sha256-AKn2SQZ8cBnoO/Q2rxvocY8uYQCThBMAz2XI5JQjiP4=",
         "owner": "padok-team",
         "repo": "baywatch",
-        "rev": "93abfe7452f60d49db336e0fa66a939b7f49dda3",
+        "rev": "d4d3fb1241ef1a303862a0fde28ccedb77d1dc76",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
         "zig": "zig"
       },
       "locked": {
-        "lastModified": 1735575681,
-        "narHash": "sha256-IAzEK0XcBqd1HdwsLfMDH5NkKSgBh0obM1h2ejayUZs=",
+        "lastModified": 1735577575,
+        "narHash": "sha256-b5b6iEkOwB49Kc8vZYiEs+4/bvxaMBT/Vyf8dfLhLM4=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "ff50b5539efc343fa69dac97e1449a75c89141f5",
+        "rev": "e17bb6964501745e06b9031c98edba7d79c7bba1",
         "type": "github"
       },
       "original": {
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735053786,
-        "narHash": "sha256-Gm+0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw=",
+        "lastModified": 1735381016,
+        "narHash": "sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84",
+        "rev": "10e99c43cdf4a0713b4e81d90691d22c6a58bdf2",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735222882,
-        "narHash": "sha256-kWNi45/mRjQMG+UpaZQ7KyPavYrKfle3WgLn9YeBBVg=",
+        "lastModified": 1735443188,
+        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "7e3246f6ad43b44bc1c16d580d7bf6467f971530",
+        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
         "type": "github"
       },
       "original": {
@@ -196,11 +196,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1734954597,
-        "narHash": "sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl+fk=",
+        "lastModified": 1735388221,
+        "narHash": "sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "def1d472c832d77885f174089b0d34854b007198",
+        "rev": "7c674c6734f61157e321db595dbfcd8523e04e19",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1735471104,
+        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
         "type": "github"
       },
       "original": {
@@ -380,11 +380,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1734546875,
-        "narHash": "sha256-6OvJbqQ6qPpNw3CA+W8Myo5aaLhIJY/nNFDk3zMXLfM=",
+        "lastModified": 1735468296,
+        "narHash": "sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "ed091321f4dd88afc28b5b4456e0a15bd8374b4d",
+        "rev": "bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'baywatch':
    'github:padok-team/baywatch/93abfe7452f60d49db336e0fa66a939b7f49dda3?narHash=sha256-QoOWFxVB0xcjpOfODNKYAkWSvYchnopHcVeJOcnBgDQ%3D' (2024-11-22)
  → 'github:padok-team/baywatch/d4d3fb1241ef1a303862a0fde28ccedb77d1dc76?narHash=sha256-AKn2SQZ8cBnoO/Q2rxvocY8uYQCThBMAz2XI5JQjiP4%3D' (2024-11-22)
• Updated input 'ghostty':
    'github:ghostty-org/ghostty/ff50b5539efc343fa69dac97e1449a75c89141f5?narHash=sha256-IAzEK0XcBqd1HdwsLfMDH5NkKSgBh0obM1h2ejayUZs%3D' (2024-12-30)
  → 'github:ghostty-org/ghostty/e17bb6964501745e06b9031c98edba7d79c7bba1?narHash=sha256-b5b6iEkOwB49Kc8vZYiEs%2B4/bvxaMBT/Vyf8dfLhLM4%3D' (2024-12-30)
• Updated input 'home-manager':
    'github:nix-community/home-manager/35b98d20ca8f4ca1f6a2c30b8a2c8bb305a36d84?narHash=sha256-Gm%2B0DcbUS338vvkwyYWms5jsWlx8z8MeQBzcnIDuIkw%3D' (2024-12-24)
  → 'github:nix-community/home-manager/10e99c43cdf4a0713b4e81d90691d22c6a58bdf2?narHash=sha256-CyCZFhMUkuYbSD6bxB/r43EdmDE7hYeZZPTCv0GudO4%3D' (2024-12-28)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/7e3246f6ad43b44bc1c16d580d7bf6467f971530?narHash=sha256-kWNi45/mRjQMG%2BUpaZQ7KyPavYrKfle3WgLn9YeBBVg%3D' (2024-12-26)
  → 'github:nix-community/nix-index-database/55ab1e1df5daf2476e6b826b69a82862dcbd7544?narHash=sha256-AydPpRBh8%2BNOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8%3D' (2024-12-29)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/def1d472c832d77885f174089b0d34854b007198?narHash=sha256-QIhd8/0x30gEv8XEE1iAnrdMlKuQ0EzthfDR7Hwl%2Bfk%3D' (2024-12-23)
  → 'github:NixOS/nixos-hardware/7c674c6734f61157e321db595dbfcd8523e04e19?narHash=sha256-e5IOgjQf0SZcFCEV/gMGrsI0gCJyqOKShBQU0iiM3Kg%3D' (2024-12-28)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507?narHash=sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ%3D' (2024-12-19)
  → 'github:nixos/nixpkgs/88195a94f390381c6afcdaa933c2f6ff93959cb4?narHash=sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs%3D' (2024-12-29)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/ed091321f4dd88afc28b5b4456e0a15bd8374b4d?narHash=sha256-6OvJbqQ6qPpNw3CA%2BW8Myo5aaLhIJY/nNFDk3zMXLfM%3D' (2024-12-18)
  → 'github:Mic92/sops-nix/bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27?narHash=sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8%3D' (2024-12-29)
```