### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -292,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735468296,
-        "narHash": "sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8=",
+        "lastModified": 1735844895,
+        "narHash": "sha256-CIRlqX9tBK2awJkmVu2cKuap/0QziDXStQZ/u/+e8Z4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27",
+        "rev": "24d89184adf76d7ccc99e659dc5f3838efb5ee32",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'sops-nix':
    'github:Mic92/sops-nix/bcb8b65aa596866eb7e5c3e1a6cccbf5d1560b27?narHash=sha256-ZjUjbvS06jf4fElOF4ve8EHjbpbRVHHypStoY8HGzk8%3D' (2024-12-29)
  → 'github:Mic92/sops-nix/24d89184adf76d7ccc99e659dc5f3838efb5ee32?narHash=sha256-CIRlqX9tBK2awJkmVu2cKuap/0QziDXStQZ/u/%2Be8Z4%3D' (2025-01-02)
```