### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735947440,
-        "narHash": "sha256-jnEcfmOhWntmVEcqlvs+j532+mvmgsKtQSSfukgkn+A=",
+        "lastModified": 1736013363,
+        "narHash": "sha256-P4lsS2Y5GzBfC8OfXtD/xWEucX6oHGTjOzjEjEJbXfc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a9987622b7b93c82e147f198574e8e6ffbf5e327",
+        "rev": "0d7908bd09165db6699908b7e3970f137327cbf0",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735443188,
-        "narHash": "sha256-AydPpRBh8+NOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8=",
+        "lastModified": 1736047960,
+        "narHash": "sha256-hutd85FA1jUJhhqBRRJ+u7UHO9oFGD/RVm2x5w8WjVQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "55ab1e1df5daf2476e6b826b69a82862dcbd7544",
+        "rev": "816a6ae88774ba7e74314830546c29e134e0dffb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/a9987622b7b93c82e147f198574e8e6ffbf5e327?narHash=sha256-jnEcfmOhWntmVEcqlvs%2Bj532%2BmvmgsKtQSSfukgkn%2BA%3D' (2025-01-03)
  → 'github:nix-community/home-manager/0d7908bd09165db6699908b7e3970f137327cbf0?narHash=sha256-P4lsS2Y5GzBfC8OfXtD/xWEucX6oHGTjOzjEjEJbXfc%3D' (2025-01-04)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/55ab1e1df5daf2476e6b826b69a82862dcbd7544?narHash=sha256-AydPpRBh8%2BNOkrLylG7vTsHrGO2b5L7XkMEL5HlzcA8%3D' (2024-12-29)
  → 'github:nix-community/nix-index-database/816a6ae88774ba7e74314830546c29e134e0dffb?narHash=sha256-hutd85FA1jUJhhqBRRJ%2Bu7UHO9oFGD/RVm2x5w8WjVQ%3D' (2025-01-05)
```