### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736013363,
-        "narHash": "sha256-P4lsS2Y5GzBfC8OfXtD/xWEucX6oHGTjOzjEjEJbXfc=",
+        "lastModified": 1736089250,
+        "narHash": "sha256-/LPWMiiJGPHGd7ZYEgmbE2da4zvBW0acmshUjYC3WG4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0d7908bd09165db6699908b7e3970f137327cbf0",
+        "rev": "172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735844895,
-        "narHash": "sha256-CIRlqX9tBK2awJkmVu2cKuap/0QziDXStQZ/u/+e8Z4=",
+        "lastModified": 1736064798,
+        "narHash": "sha256-xJRN0FmX9QJ6+w8eIIIxzBU1AyQcLKJ1M/Gp6lnSD20=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "24d89184adf76d7ccc99e659dc5f3838efb5ee32",
+        "rev": "5dc08f9cc77f03b43aacffdfbc8316807773c930",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/0d7908bd09165db6699908b7e3970f137327cbf0?narHash=sha256-P4lsS2Y5GzBfC8OfXtD/xWEucX6oHGTjOzjEjEJbXfc%3D' (2025-01-04)
  → 'github:nix-community/home-manager/172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196?narHash=sha256-/LPWMiiJGPHGd7ZYEgmbE2da4zvBW0acmshUjYC3WG4%3D' (2025-01-05)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/24d89184adf76d7ccc99e659dc5f3838efb5ee32?narHash=sha256-CIRlqX9tBK2awJkmVu2cKuap/0QziDXStQZ/u/%2Be8Z4%3D' (2025-01-02)
  → 'github:Mic92/sops-nix/5dc08f9cc77f03b43aacffdfbc8316807773c930?narHash=sha256-xJRN0FmX9QJ6%2Bw8eIIIxzBU1AyQcLKJ1M/Gp6lnSD20%3D' (2025-01-05)
```