### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736089250,
-        "narHash": "sha256-/LPWMiiJGPHGd7ZYEgmbE2da4zvBW0acmshUjYC3WG4=",
+        "lastModified": 1736204492,
+        "narHash": "sha256-CoBPRgkUex9Iz6qGSzi/BFVUQjndB0PmME2B6eEyeCs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196",
+        "rev": "20665c6efa83d71020c8730f26706258ba5c6b2a",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736064798,
-        "narHash": "sha256-xJRN0FmX9QJ6+w8eIIIxzBU1AyQcLKJ1M/Gp6lnSD20=",
+        "lastModified": 1736203741,
+        "narHash": "sha256-eSjkBwBdQk+TZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "5dc08f9cc77f03b43aacffdfbc8316807773c930",
+        "rev": "c9c88f08e3ee495e888b8d7c8624a0b2519cb773",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/172b91bfb2b7f5c4a8c6ceac29fd53a01ef07196?narHash=sha256-/LPWMiiJGPHGd7ZYEgmbE2da4zvBW0acmshUjYC3WG4%3D' (2025-01-05)
  → 'github:nix-community/home-manager/20665c6efa83d71020c8730f26706258ba5c6b2a?narHash=sha256-CoBPRgkUex9Iz6qGSzi/BFVUQjndB0PmME2B6eEyeCs%3D' (2025-01-06)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/5dc08f9cc77f03b43aacffdfbc8316807773c930?narHash=sha256-xJRN0FmX9QJ6%2Bw8eIIIxzBU1AyQcLKJ1M/Gp6lnSD20%3D' (2025-01-05)
  → 'github:Mic92/sops-nix/c9c88f08e3ee495e888b8d7c8624a0b2519cb773?narHash=sha256-eSjkBwBdQk%2BTZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4%3D' (2025-01-06)
```