### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736421950,
-        "narHash": "sha256-RyrX0WFXxFrYvzHNLTIyuk3NcNl3UBykuYru/P0zW5E=",
+        "lastModified": 1736508663,
+        "narHash": "sha256-ZOaGwa+WnB7Zn3YXimqjmIugAnHePdXCmNu+AHkq808=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d4aebb947a301b8da8654a804979a738c5c5da50",
+        "rev": "2532b500c3ed2b8940e831039dcec5a5ea093afc",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735049224,
-        "narHash": "sha256-fWUd9kyXdepphJ7cCzOsuSo7l0kbFCkUqfgKqZyFZzE=",
+        "lastModified": 1736549395,
+        "narHash": "sha256-XzwkB62Tt5UYoL1jXiHzgk/qz2fUpGHExcSIbyGTtI0=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "d16bbded0ae452bc088489e7dca3ef58d8d1830b",
+        "rev": "a53af7f1514ef4cce8620a9d6a50f238cdedec8b",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736203741,
-        "narHash": "sha256-eSjkBwBdQk+TZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4=",
+        "lastModified": 1736515725,
+        "narHash": "sha256-4P99yL8vGehwzytkpP87eklBePt6aqeEC5JFsIzhfUs=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c9c88f08e3ee495e888b8d7c8624a0b2519cb773",
+        "rev": "f214c1b76c347a4e9c8fb68c73d4293a6820d125",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d4aebb947a301b8da8654a804979a738c5c5da50?narHash=sha256-RyrX0WFXxFrYvzHNLTIyuk3NcNl3UBykuYru/P0zW5E%3D' (2025-01-09)
  → 'github:nix-community/home-manager/2532b500c3ed2b8940e831039dcec5a5ea093afc?narHash=sha256-ZOaGwa%2BWnB7Zn3YXimqjmIugAnHePdXCmNu%2BAHkq808%3D' (2025-01-10)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/d16bbded0ae452bc088489e7dca3ef58d8d1830b?narHash=sha256-fWUd9kyXdepphJ7cCzOsuSo7l0kbFCkUqfgKqZyFZzE%3D' (2024-12-24)
  → 'github:nix-community/plasma-manager/a53af7f1514ef4cce8620a9d6a50f238cdedec8b?narHash=sha256-XzwkB62Tt5UYoL1jXiHzgk/qz2fUpGHExcSIbyGTtI0%3D' (2025-01-10)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/c9c88f08e3ee495e888b8d7c8624a0b2519cb773?narHash=sha256-eSjkBwBdQk%2BTZWFlLbclF2rAh4JxbGg8az4w/Lfe7f4%3D' (2025-01-06)
  → 'github:Mic92/sops-nix/f214c1b76c347a4e9c8fb68c73d4293a6820d125?narHash=sha256-4P99yL8vGehwzytkpP87eklBePt6aqeEC5JFsIzhfUs%3D' (2025-01-10)
```