### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736508663,
-        "narHash": "sha256-ZOaGwa+WnB7Zn3YXimqjmIugAnHePdXCmNu+AHkq808=",
+        "lastModified": 1736785676,
+        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "2532b500c3ed2b8940e831039dcec5a5ea093afc",
+        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736523798,
-        "narHash": "sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s=",
+        "lastModified": 1736701207,
+        "narHash": "sha256-jG/+MvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "130595eba61081acde9001f43de3248d8888ac4a",
+        "rev": "ed4a395ea001367c1f13d34b1e01aa10290f67d6",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736515725,
-        "narHash": "sha256-4P99yL8vGehwzytkpP87eklBePt6aqeEC5JFsIzhfUs=",
+        "lastModified": 1736808430,
+        "narHash": "sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f214c1b76c347a4e9c8fb68c73d4293a6820d125",
+        "rev": "553c7cb22fed19fd60eb310423fdc93045c51ba8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/2532b500c3ed2b8940e831039dcec5a5ea093afc?narHash=sha256-ZOaGwa%2BWnB7Zn3YXimqjmIugAnHePdXCmNu%2BAHkq808%3D' (2025-01-10)
  → 'github:nix-community/home-manager/fc52a210b60f2f52c74eac41a8647c1573d2071d?narHash=sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m%2BYq%2B%2BC9AyE%3D' (2025-01-13)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/130595eba61081acde9001f43de3248d8888ac4a?narHash=sha256-Xb8mke6UCYjge9kPR9o4P1nVrhk7QBbKv3xQ9cj7h2s%3D' (2025-01-10)
  → 'github:nixos/nixpkgs/ed4a395ea001367c1f13d34b1e01aa10290f67d6?narHash=sha256-jG/%2BMvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA%3D' (2025-01-12)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/f214c1b76c347a4e9c8fb68c73d4293a6820d125?narHash=sha256-4P99yL8vGehwzytkpP87eklBePt6aqeEC5JFsIzhfUs%3D' (2025-01-10)
  → 'github:Mic92/sops-nix/553c7cb22fed19fd60eb310423fdc93045c51ba8?narHash=sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk%3D' (2025-01-13)
```