### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736441705,
-        "narHash": "sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb+mxySIP93o=",
+        "lastModified": 1736978406,
+        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "8870dcaff63dfc6647fb10648b827e9d40b0a337",
+        "rev": "b678606690027913f3434dea3864e712b862dde5",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736701207,
-        "narHash": "sha256-jG/+MvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA=",
+        "lastModified": 1736883708,
+        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ed4a395ea001367c1f13d34b1e01aa10290f67d6",
+        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/8870dcaff63dfc6647fb10648b827e9d40b0a337?narHash=sha256-OL7leZ6KBhcDF3nEKe4aZVfIm6xQpb1Kb%2BmxySIP93o%3D' (2025-01-09)
  → 'github:NixOS/nixos-hardware/b678606690027913f3434dea3864e712b862dde5?narHash=sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk%3D' (2025-01-15)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/ed4a395ea001367c1f13d34b1e01aa10290f67d6?narHash=sha256-jG/%2BMvjVY7SlTakzZ2fJ5dC3V1PrKKrUEOEE30jrOKA%3D' (2025-01-12)
  → 'github:nixos/nixpkgs/eb62e6aa39ea67e0b8018ba8ea077efe65807dc8?narHash=sha256-uQ%2BNQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140%3D' (2025-01-14)
```