### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736785676,
-        "narHash": "sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m+Yq++C9AyE=",
+        "lastModified": 1737075266,
+        "narHash": "sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fc52a210b60f2f52c74eac41a8647c1573d2071d",
+        "rev": "12851ae7467bad8ef422b20806ab4d6d81e12d29",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735823209,
-        "narHash": "sha256-NWpVXiTrTp8x/MVOhL0aNK69MJBEon3RpD25Ys08vio=",
+        "lastModified": 1737038300,
+        "narHash": "sha256-N9bMW7Bw/1xLB58j8rbXS1Qh4LRk47LgzIk0xwJ1dqs=",
         "owner": "cterence",
         "repo": "nixos-work-config",
-        "rev": "a7f91a734fcf975a6541c54a3f295f9ad18026a9",
+        "rev": "5eed56075fc354ff5acdaf16246f5090989328dc",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1735882644,
-        "narHash": "sha256-3FZAG+pGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110=",
+        "lastModified": 1737043064,
+        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "a5a961387e75ae44cc20f0a57ae463da5e959656",
+        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/fc52a210b60f2f52c74eac41a8647c1573d2071d?narHash=sha256-TY0jUwR3EW0fnS0X5wXMAVy6h4Z7Y6a3m%2BYq%2B%2BC9AyE%3D' (2025-01-13)
  → 'github:nix-community/home-manager/12851ae7467bad8ef422b20806ab4d6d81e12d29?narHash=sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo%3D' (2025-01-17)
• Updated input 'nixos-work-config':
    'github:cterence/nixos-work-config/a7f91a734fcf975a6541c54a3f295f9ad18026a9?narHash=sha256-NWpVXiTrTp8x/MVOhL0aNK69MJBEon3RpD25Ys08vio%3D' (2025-01-02)
  → 'github:cterence/nixos-work-config/5eed56075fc354ff5acdaf16246f5090989328dc?narHash=sha256-N9bMW7Bw/1xLB58j8rbXS1Qh4LRk47LgzIk0xwJ1dqs%3D' (2025-01-16)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/a5a961387e75ae44cc20f0a57ae463da5e959656?narHash=sha256-3FZAG%2BpGt3OElQjesCAWeMkQ7C/nB1oTHLRQ8ceP110%3D' (2025-01-03)
  → 'github:cachix/git-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb?narHash=sha256-I/OuxGwXwRi5gnFPsyCvVR%2BIfFstA%2BQXEpHu1hvsgD8%3D' (2025-01-16)
```