### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737075266,
-        "narHash": "sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo=",
+        "lastModified": 1737120639,
+        "narHash": "sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "12851ae7467bad8ef422b20806ab4d6d81e12d29",
+        "rev": "a0046af169ce7b1da503974e1b22c48ef4d71887",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736883708,
-        "narHash": "sha256-uQ+NQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140=",
+        "lastModified": 1737062831,
+        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "eb62e6aa39ea67e0b8018ba8ea077efe65807dc8",
+        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736808430,
-        "narHash": "sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk=",
+        "lastModified": 1737107480,
+        "narHash": "sha256-GXUE9+FgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "553c7cb22fed19fd60eb310423fdc93045c51ba8",
+        "rev": "4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/12851ae7467bad8ef422b20806ab4d6d81e12d29?narHash=sha256-u1gk5I1an975FOAMMdS6oBKnSIsZza5ZKhaeBZAskVo%3D' (2025-01-17)
  → 'github:nix-community/home-manager/a0046af169ce7b1da503974e1b22c48ef4d71887?narHash=sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI%3D' (2025-01-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/eb62e6aa39ea67e0b8018ba8ea077efe65807dc8?narHash=sha256-uQ%2BNQ0/xYU0N1CnXsa2zghgNaOPxWpMJXSUJJ9W7140%3D' (2025-01-14)
  → 'github:nixos/nixpkgs/5df43628fdf08d642be8ba5b3625a6c70731c19c?narHash=sha256-Tbk1MZbtV2s5aG%2BiM99U8FqwxU/YNArMcWAv6clcsBc%3D' (2025-01-16)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/553c7cb22fed19fd60eb310423fdc93045c51ba8?narHash=sha256-wlgdf/n7bJMLBheqt1jmPoxJFrUP6FByKQFXuM9YvIk%3D' (2025-01-13)
  → 'github:Mic92/sops-nix/4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6?narHash=sha256-GXUE9%2BFgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o%3D' (2025-01-17)
```