### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737120639,
-        "narHash": "sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI=",
+        "lastModified": 1737221749,
+        "narHash": "sha256-igllW0yG+UbetvhT11jnt9RppSHXYgMykYhZJeqfHs0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a0046af169ce7b1da503974e1b22c48ef4d71887",
+        "rev": "97d7946b5e107dd03cc82f21165251d4e0159655",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736652904,
-        "narHash": "sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM=",
+        "lastModified": 1737257306,
+        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "271e5bd7c57e1f001693799518b10a02d1123b12",
+        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/a0046af169ce7b1da503974e1b22c48ef4d71887?narHash=sha256-p5e/45V41YD3tMELuiNIoVCa25/w4nhOTm0B9MtdHFI%3D' (2025-01-17)
  → 'github:nix-community/home-manager/97d7946b5e107dd03cc82f21165251d4e0159655?narHash=sha256-igllW0yG%2BUbetvhT11jnt9RppSHXYgMykYhZJeqfHs0%3D' (2025-01-18)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/271e5bd7c57e1f001693799518b10a02d1123b12?narHash=sha256-8uolHABgroXqzs03QdulHp8H9e5kWQZnnhcda1MKbBM%3D' (2025-01-12)
  → 'github:nix-community/nix-index-database/744d330659e207a1883d2da0141d35e520eb87bd?narHash=sha256-lEGgpA4kGafc76%2BAmnz%2Bgh1L/cwUS2pePFlf22WEyh8%3D' (2025-01-19)
```