### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737221749,
-        "narHash": "sha256-igllW0yG+UbetvhT11jnt9RppSHXYgMykYhZJeqfHs0=",
+        "lastModified": 1737299337,
+        "narHash": "sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "97d7946b5e107dd03cc82f21165251d4e0159655",
+        "rev": "f8ef4541bb8a54a8b52f19b52912119e689529b3",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1736978406,
-        "narHash": "sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk=",
+        "lastModified": 1737359802,
+        "narHash": "sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "b678606690027913f3434dea3864e712b862dde5",
+        "rev": "61c79181e77ef774ab0468b28a24bc2647d498d6",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737043064,
-        "narHash": "sha256-I/OuxGwXwRi5gnFPsyCvVR+IfFstA+QXEpHu1hvsgD8=",
+        "lastModified": 1737301351,
+        "narHash": "sha256-2UNmLCKORvdBRhPGI8Vx0b6l7M8/QBey/nHLIxOl4jE=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "94ee657f6032d913fe0ef49adaa743804635b0bb",
+        "rev": "15a87cedeb67e3dbc8d2f7b9831990dffcf4e69f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/97d7946b5e107dd03cc82f21165251d4e0159655?narHash=sha256-igllW0yG%2BUbetvhT11jnt9RppSHXYgMykYhZJeqfHs0%3D' (2025-01-18)
  → 'github:nix-community/home-manager/f8ef4541bb8a54a8b52f19b52912119e689529b3?narHash=sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw%3D' (2025-01-19)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/b678606690027913f3434dea3864e712b862dde5?narHash=sha256-oMr3PVIQ8XPDI8/x6BHxsWEPBRU98Pam6KGVwUh8MPk%3D' (2025-01-15)
  → 'github:NixOS/nixos-hardware/61c79181e77ef774ab0468b28a24bc2647d498d6?narHash=sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8%3D' (2025-01-20)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/94ee657f6032d913fe0ef49adaa743804635b0bb?narHash=sha256-I/OuxGwXwRi5gnFPsyCvVR%2BIfFstA%2BQXEpHu1hvsgD8%3D' (2025-01-16)
  → 'github:cachix/git-hooks.nix/15a87cedeb67e3dbc8d2f7b9831990dffcf4e69f?narHash=sha256-2UNmLCKORvdBRhPGI8Vx0b6l7M8/QBey/nHLIxOl4jE%3D' (2025-01-19)
```