### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737299337,
-        "narHash": "sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw=",
+        "lastModified": 1737394973,
+        "narHash": "sha256-EW4oXMfnfA5sNM9Jqm+y98horWVvN66Gu7YIcEpFYZc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f8ef4541bb8a54a8b52f19b52912119e689529b3",
+        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737107480,
-        "narHash": "sha256-GXUE9+FgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o=",
+        "lastModified": 1737411508,
+        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6",
+        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f8ef4541bb8a54a8b52f19b52912119e689529b3?narHash=sha256-0NBrY2A7buujKmeCbieopOMSbLxTu8TFcTLqAbTnQDw%3D' (2025-01-19)
  → 'github:nix-community/home-manager/9786661d57c476021c8a0c3e53bf9fa2b4f3328b?narHash=sha256-EW4oXMfnfA5sNM9Jqm%2By98horWVvN66Gu7YIcEpFYZc%3D' (2025-01-20)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/4c4fb93f18b9072c6fa1986221f9a3d7bf1fe4b6?narHash=sha256-GXUE9%2BFgxoZU8v0p6ilBJ8NH7k8nKmZjp/7dmMrCv3o%3D' (2025-01-17)
  → 'github:Mic92/sops-nix/015d461c16678fc02a2f405eb453abb509d4e1d4?narHash=sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw%3D' (2025-01-20)
```