### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737394973,
-        "narHash": "sha256-EW4oXMfnfA5sNM9Jqm+y98horWVvN66Gu7YIcEpFYZc=",
+        "lastModified": 1738275749,
+        "narHash": "sha256-PM+cGduJ05EZ+YXulqAwUFjvfKpPmW080mcuN6R1POw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9786661d57c476021c8a0c3e53bf9fa2b4f3328b",
+        "rev": "a8159195bfaef3c64df75d3b1e6a68d49d392be9",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737257306,
-        "narHash": "sha256-lEGgpA4kGafc76+Amnz+gh1L/cwUS2pePFlf22WEyh8=",
+        "lastModified": 1737861961,
+        "narHash": "sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf+TpE=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "744d330659e207a1883d2da0141d35e520eb87bd",
+        "rev": "79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1737359802,
-        "narHash": "sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8=",
+        "lastModified": 1737751639,
+        "narHash": "sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "61c79181e77ef774ab0468b28a24bc2647d498d6",
+        "rev": "dfad538f751a5aa5d4436d9781ab27a6128ec9d4",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1738142207,
+        "narHash": "sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9+WC4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "9d3ae807ebd2981d593cddd0080856873139aa40",
         "type": "github"
       },
       "original": {
@@ -239,11 +239,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737301351,
-        "narHash": "sha256-2UNmLCKORvdBRhPGI8Vx0b6l7M8/QBey/nHLIxOl4jE=",
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "15a87cedeb67e3dbc8d2f7b9831990dffcf4e69f",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
         "type": "github"
       },
       "original": {
@@ -275,11 +275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737411508,
-        "narHash": "sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw=",
+        "lastModified": 1738291974,
+        "narHash": "sha256-wkwYJc8cKmmQWUloyS9KwttBnja2ONRuJQDEsmef320=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "015d461c16678fc02a2f405eb453abb509d4e1d4",
+        "rev": "4c1251904d8a08c86ac6bc0d72cc09975e89aef7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/9786661d57c476021c8a0c3e53bf9fa2b4f3328b?narHash=sha256-EW4oXMfnfA5sNM9Jqm%2By98horWVvN66Gu7YIcEpFYZc%3D' (2025-01-20)
  → 'github:nix-community/home-manager/a8159195bfaef3c64df75d3b1e6a68d49d392be9?narHash=sha256-PM%2BcGduJ05EZ%2BYXulqAwUFjvfKpPmW080mcuN6R1POw%3D' (2025-01-30)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/744d330659e207a1883d2da0141d35e520eb87bd?narHash=sha256-lEGgpA4kGafc76%2BAmnz%2Bgh1L/cwUS2pePFlf22WEyh8%3D' (2025-01-19)
  → 'github:nix-community/nix-index-database/79b7b8eae3243fc5aa9aad34ba6b9bbb2266f523?narHash=sha256-LIRtMvAwLGb8pBoamzgEF67oKlNPz4LuXiRPVZf%2BTpE%3D' (2025-01-26)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/61c79181e77ef774ab0468b28a24bc2647d498d6?narHash=sha256-utplyRM6pqnN940gfaLFBb9oUCSzkan86IvmkhsVlN8%3D' (2025-01-20)
  → 'github:NixOS/nixos-hardware/dfad538f751a5aa5d4436d9781ab27a6128ec9d4?narHash=sha256-ZEbOJ9iT72iwqXsiEMbEa8wWjyFvRA9Ugx8utmYbpz4%3D' (2025-01-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/5df43628fdf08d642be8ba5b3625a6c70731c19c?narHash=sha256-Tbk1MZbtV2s5aG%2BiM99U8FqwxU/YNArMcWAv6clcsBc%3D' (2025-01-16)
  → 'github:nixos/nixpkgs/9d3ae807ebd2981d593cddd0080856873139aa40?narHash=sha256-NGqpVVxNAHwIicXpgaVqJEJWeyqzoQJ9oc8lnK9%2BWC4%3D' (2025-01-29)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/15a87cedeb67e3dbc8d2f7b9831990dffcf4e69f?narHash=sha256-2UNmLCKORvdBRhPGI8Vx0b6l7M8/QBey/nHLIxOl4jE%3D' (2025-01-19)
  → 'github:cachix/git-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17?narHash=sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg%3D' (2025-01-21)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/015d461c16678fc02a2f405eb453abb509d4e1d4?narHash=sha256-j9IdflJwRtqo9WpM0OfAZml47eBblUHGNQTe62OUqTw%3D' (2025-01-20)
  → 'github:Mic92/sops-nix/4c1251904d8a08c86ac6bc0d72cc09975e89aef7?narHash=sha256-wkwYJc8cKmmQWUloyS9KwttBnja2ONRuJQDEsmef320%3D' (2025-01-31)
```