### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738448366,
-        "narHash": "sha256-4ATtQqBlgsGqkHTemta0ydY6f7JBRXz4Hf574NHQpkg=",
+        "lastModified": 1738610386,
+        "narHash": "sha256-yb6a5efA1e8xze1vcdN2HBxqYr340EsxFMrDUHL3WZM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18fa9f323d8adbb0b7b8b98a8488db308210ed93",
+        "rev": "066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738471961,
-        "narHash": "sha256-cgXDFrplNGs7bCVzXhRofjD8oJYqqXGcmUzXjHmip6Y=",
+        "lastModified": 1738638143,
+        "narHash": "sha256-ZYMe4c4OCtIUBn5hx15PEGr0+B1cNEpl2dsaLxwY2W0=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "537286c3c59b40311e5418a180b38034661d2536",
+        "rev": "9bdd53f5908453e4d03f395eb1615c3e9a351f70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/18fa9f323d8adbb0b7b8b98a8488db308210ed93?narHash=sha256-4ATtQqBlgsGqkHTemta0ydY6f7JBRXz4Hf574NHQpkg%3D' (2025-02-01)
  → 'github:nix-community/home-manager/066ba0c5cfddbc9e0dddaec73b1561ad38aa8abe?narHash=sha256-yb6a5efA1e8xze1vcdN2HBxqYr340EsxFMrDUHL3WZM%3D' (2025-02-03)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/537286c3c59b40311e5418a180b38034661d2536?narHash=sha256-cgXDFrplNGs7bCVzXhRofjD8oJYqqXGcmUzXjHmip6Y%3D' (2025-02-02)
  → 'github:NixOS/nixos-hardware/9bdd53f5908453e4d03f395eb1615c3e9a351f70?narHash=sha256-ZYMe4c4OCtIUBn5hx15PEGr0%2BB1cNEpl2dsaLxwY2W0%3D' (2025-02-04)
```