### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738709900,
-        "narHash": "sha256-8Bo5xFlCH5q72ExvAnH7TzStMlLZldKOSLMClRSfmTc=",
+        "lastModified": 1738789832,
+        "narHash": "sha256-HdlMPfObPu5y7oDfH/w3vvlU3UTQ/bQjSULChZARm5M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f2d32e46fac9d51da6912948ae1156044c71774b",
+        "rev": "30ea6fed4e4b41693cebc2263373dd810de4de49",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738638143,
-        "narHash": "sha256-ZYMe4c4OCtIUBn5hx15PEGr0+B1cNEpl2dsaLxwY2W0=",
+        "lastModified": 1738814804,
+        "narHash": "sha256-b/X1gQzsqN3NJsa4BPPUP9BK5UZoK7HB15jGRsLSadI=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "9bdd53f5908453e4d03f395eb1615c3e9a351f70",
+        "rev": "d9819a6791f7e7eec0bbbaf1b79d2e0c1879b183",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f2d32e46fac9d51da6912948ae1156044c71774b?narHash=sha256-8Bo5xFlCH5q72ExvAnH7TzStMlLZldKOSLMClRSfmTc%3D' (2025-02-04)
  → 'github:nix-community/home-manager/30ea6fed4e4b41693cebc2263373dd810de4de49?narHash=sha256-HdlMPfObPu5y7oDfH/w3vvlU3UTQ/bQjSULChZARm5M%3D' (2025-02-05)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/9bdd53f5908453e4d03f395eb1615c3e9a351f70?narHash=sha256-ZYMe4c4OCtIUBn5hx15PEGr0%2BB1cNEpl2dsaLxwY2W0%3D' (2025-02-04)
  → 'github:NixOS/nixos-hardware/d9819a6791f7e7eec0bbbaf1b79d2e0c1879b183?narHash=sha256-b/X1gQzsqN3NJsa4BPPUP9BK5UZoK7HB15jGRsLSadI%3D' (2025-02-06)
```