### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1738789832,
-        "narHash": "sha256-HdlMPfObPu5y7oDfH/w3vvlU3UTQ/bQjSULChZARm5M=",
+        "lastModified": 1738878603,
+        "narHash": "sha256-fmhq8B3MvQLawLbMO+LWLcdC2ftLMmwSk+P29icJ3tE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "30ea6fed4e4b41693cebc2263373dd810de4de49",
+        "rev": "433799271274c9f2ab520a49527ebfe2992dcfbd",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738814804,
-        "narHash": "sha256-b/X1gQzsqN3NJsa4BPPUP9BK5UZoK7HB15jGRsLSadI=",
+        "lastModified": 1738816619,
+        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d9819a6791f7e7eec0bbbaf1b79d2e0c1879b183",
+        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/30ea6fed4e4b41693cebc2263373dd810de4de49?narHash=sha256-HdlMPfObPu5y7oDfH/w3vvlU3UTQ/bQjSULChZARm5M%3D' (2025-02-05)
  → 'github:nix-community/home-manager/433799271274c9f2ab520a49527ebfe2992dcfbd?narHash=sha256-fmhq8B3MvQLawLbMO%2BLWLcdC2ftLMmwSk%2BP29icJ3tE%3D' (2025-02-06)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d9819a6791f7e7eec0bbbaf1b79d2e0c1879b183?narHash=sha256-b/X1gQzsqN3NJsa4BPPUP9BK5UZoK7HB15jGRsLSadI%3D' (2025-02-06)
  → 'github:NixOS/nixos-hardware/2eccff41bab80839b1d25b303b53d339fbb07087?narHash=sha256-5yRlg48XmpcX5b5HesdGMOte%2BYuCy9rzQkJz%2Bimcu6I%3D' (2025-02-06)
```