### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739470101,
-        "narHash": "sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4=",
+        "lastModified": 1739571712,
+        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5031c6d2978109336637977c165f82aa49fa16a7",
+        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
         "type": "github"
       },
       "original": {
@@ -217,11 +217,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736549395,
-        "narHash": "sha256-XzwkB62Tt5UYoL1jXiHzgk/qz2fUpGHExcSIbyGTtI0=",
+        "lastModified": 1739557722,
+        "narHash": "sha256-XikzLpPUDYiNyJ4w2SfRShdbSkIgE3btYdxCGInmtc4=",
         "owner": "nix-community",
         "repo": "plasma-manager",
-        "rev": "a53af7f1514ef4cce8620a9d6a50f238cdedec8b",
+        "rev": "1f3e1f38dedbbb8aad77e184fb54ec518e2d9522",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/5031c6d2978109336637977c165f82aa49fa16a7?narHash=sha256-NxNe32VB4XI/xIXrsKmIfrcgtEx5r/5s52pL3CpEcA4%3D' (2025-02-13)
  → 'github:nix-community/home-manager/6d3163aea47fdb1fe19744e91306a2ea4f602292?narHash=sha256-0UdSDV/TBY%2BGuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ%3D' (2025-02-14)
• Updated input 'plasma-manager':
    'github:nix-community/plasma-manager/a53af7f1514ef4cce8620a9d6a50f238cdedec8b?narHash=sha256-XzwkB62Tt5UYoL1jXiHzgk/qz2fUpGHExcSIbyGTtI0%3D' (2025-01-10)
  → 'github:nix-community/plasma-manager/1f3e1f38dedbbb8aad77e184fb54ec518e2d9522?narHash=sha256-XikzLpPUDYiNyJ4w2SfRShdbSkIgE3btYdxCGInmtc4%3D' (2025-02-14)
```