### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739571712,
-        "narHash": "sha256-0UdSDV/TBY+GuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ=",
+        "lastModified": 1739676861,
+        "narHash": "sha256-X86ptHMNVuu1Z9leL0YV2E/oxD2IgPYrYANPcvFYpNo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6d3163aea47fdb1fe19744e91306a2ea4f602292",
+        "rev": "eb44c1601ed99896525e983bc9b15eb8b4d5879e",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739071773,
-        "narHash": "sha256-/Ak+Quinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I=",
+        "lastModified": 1739676768,
+        "narHash": "sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42+G7iIiBmlU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "895d81b6228bbd50a6ef22f5a58a504ca99763ea",
+        "rev": "ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/6d3163aea47fdb1fe19744e91306a2ea4f602292?narHash=sha256-0UdSDV/TBY%2BGuxXLbrLq3l2Fq02ciyKCIMy4qmnfJXQ%3D' (2025-02-14)
  → 'github:nix-community/home-manager/eb44c1601ed99896525e983bc9b15eb8b4d5879e?narHash=sha256-X86ptHMNVuu1Z9leL0YV2E/oxD2IgPYrYANPcvFYpNo%3D' (2025-02-16)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/895d81b6228bbd50a6ef22f5a58a504ca99763ea?narHash=sha256-/Ak%2BQuinhmdxa9m3shjm4lwwwqmzG8zzGhhhhgR1k9I%3D' (2025-02-09)
  → 'github:nix-community/nix-index-database/ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63?narHash=sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42%2BG7iIiBmlU%3D' (2025-02-16)
```