### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739756364,
-        "narHash": "sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F+DF+CTSM=",
+        "lastModified": 1739845242,
+        "narHash": "sha256-rNMXpDubNWGLTs45MuoH9YHtXfXye/fn2u4YMSTPt9I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "662fa98bf488daa82ce8dc2bc443872952065ab9",
+        "rev": "5cfbf5cc37a3bd1da07ae84eea1b828909c4456b",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1738816619,
-        "narHash": "sha256-5yRlg48XmpcX5b5HesdGMOte+YuCy9rzQkJz+imcu6I=",
+        "lastModified": 1739798439,
+        "narHash": "sha256-GyipmjbbQEaosel/+wq1xihCKbv0/e1LU00x/8b/fP4=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "2eccff41bab80839b1d25b303b53d339fbb07087",
+        "rev": "3e2ea8a49d4d76276b0f4e2041df8ca5c0771371",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739580444,
-        "narHash": "sha256-+/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN+24g4=",
+        "lastModified": 1739736696,
+        "narHash": "sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb+P+R4S8Jsw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bb37161a0488b89830168b81c48aed11569cb93",
+        "rev": "d74a2335ac9c133d6bbec9fc98d91a77f1604c1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/662fa98bf488daa82ce8dc2bc443872952065ab9?narHash=sha256-r8RxE0W3uhJ6unzbIddWTAzrpP9tMnmbj0F%2BDF%2BCTSM%3D' (2025-02-17)
  → 'github:nix-community/home-manager/5cfbf5cc37a3bd1da07ae84eea1b828909c4456b?narHash=sha256-rNMXpDubNWGLTs45MuoH9YHtXfXye/fn2u4YMSTPt9I%3D' (2025-02-18)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/2eccff41bab80839b1d25b303b53d339fbb07087?narHash=sha256-5yRlg48XmpcX5b5HesdGMOte%2BYuCy9rzQkJz%2Bimcu6I%3D' (2025-02-06)
  → 'github:NixOS/nixos-hardware/3e2ea8a49d4d76276b0f4e2041df8ca5c0771371?narHash=sha256-GyipmjbbQEaosel/%2Bwq1xihCKbv0/e1LU00x/8b/fP4%3D' (2025-02-17)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/8bb37161a0488b89830168b81c48aed11569cb93?narHash=sha256-%2B/bSz4EAVbqz8/HsIGLroF8aNaO8bLRL7WfACN%2B24g4%3D' (2025-02-15)
  → 'github:nixos/nixpkgs/d74a2335ac9c133d6bbec9fc98d91a77f1604c1f?narHash=sha256-zON2GNBkzsIyALlOCFiEBcIjI4w38GYOb%2BP%2BR4S8Jsw%3D' (2025-02-16)
```