### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739992710,
-        "narHash": "sha256-9kEscmGnXHjSgcqyJR4TzzHhska4yz1inSQs6HuO9qU=",
+        "lastModified": 1740060750,
+        "narHash": "sha256-FOC9OzJ5Ckh6VjzGSRh4F3UCUOdM8NrzQT19PQcQJ44=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c189f011447810af939a886ba7bee33532bb1f9",
+        "rev": "0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c",
         "type": "github"
       },
       "original": {
@@ -141,11 +141,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1739798439,
-        "narHash": "sha256-GyipmjbbQEaosel/+wq1xihCKbv0/e1LU00x/8b/fP4=",
+        "lastModified": 1740089251,
+        "narHash": "sha256-Y78mDBWoO8CLLTjQfPfII+KXFb6lAmF9GrLbyVBsIMM=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "3e2ea8a49d4d76276b0f4e2041df8ca5c0771371",
+        "rev": "18e9f9753e9ae261bcc7d3abe15745686991fd30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/1c189f011447810af939a886ba7bee33532bb1f9?narHash=sha256-9kEscmGnXHjSgcqyJR4TzzHhska4yz1inSQs6HuO9qU%3D' (2025-02-19)
  → 'github:nix-community/home-manager/0c0b0ac8af6ca76b1fcb514483a9bd73c18f1e8c?narHash=sha256-FOC9OzJ5Ckh6VjzGSRh4F3UCUOdM8NrzQT19PQcQJ44%3D' (2025-02-20)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/3e2ea8a49d4d76276b0f4e2041df8ca5c0771371?narHash=sha256-GyipmjbbQEaosel/%2Bwq1xihCKbv0/e1LU00x/8b/fP4%3D' (2025-02-17)
  → 'github:NixOS/nixos-hardware/18e9f9753e9ae261bcc7d3abe15745686991fd30?narHash=sha256-Y78mDBWoO8CLLTjQfPfII%2BKXFb6lAmF9GrLbyVBsIMM%3D' (2025-02-20)
```