### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740188029,
-        "narHash": "sha256-pnPs+XSpR633G/q0gj+SDyL4RaDfiKlom86zEBPtq+M=",
+        "lastModified": 1740283128,
+        "narHash": "sha256-R61wtNknWWejnl+K0l4sxu/wnLNFbNe44tNM2zbj5yE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb",
+        "rev": "ed030a787938cae01d693ebaad52bbb672a4a69d",
         "type": "github"
       },
       "original": {
@@ -126,11 +126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739676768,
-        "narHash": "sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42+G7iIiBmlU=",
+        "lastModified": 1740281615,
+        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63",
+        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/765cb91e9d5ab06ed8c92c25fc0e51d6c11d43cb?narHash=sha256-pnPs%2BXSpR633G/q0gj%2BSDyL4RaDfiKlom86zEBPtq%2BM%3D' (2025-02-22)
  → 'github:nix-community/home-manager/ed030a787938cae01d693ebaad52bbb672a4a69d?narHash=sha256-R61wtNknWWejnl%2BK0l4sxu/wnLNFbNe44tNM2zbj5yE%3D' (2025-02-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/ae15068e79e22b76c344f0d7f8aed1bb1c5b0b63?narHash=sha256-U1HQ7nzhJyVVXUgjU028UCkbLQLEIkg42%2BG7iIiBmlU%3D' (2025-02-16)
  → 'github:nix-community/nix-index-database/465792533d03e6bb9dc849d58ab9d5e31fac9023?narHash=sha256-dZWcbAQ1sF8oVv%2BzjSKkPVY0ebwENQEkz5vc6muXbKY%3D' (2025-02-23)
```