### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740283128,
-        "narHash": "sha256-R61wtNknWWejnl+K0l4sxu/wnLNFbNe44tNM2zbj5yE=",
+        "lastModified": 1740432748,
+        "narHash": "sha256-BCeFtoJ/+LrZc03viRJWHfzAqqG8gPu/ikZeurv05xs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ed030a787938cae01d693ebaad52bbb672a4a69d",
+        "rev": "c12dcc9b61429b2ad437a7d4974399ad8f910319",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740089251,
-        "narHash": "sha256-Y78mDBWoO8CLLTjQfPfII+KXFb6lAmF9GrLbyVBsIMM=",
+        "lastModified": 1740387674,
+        "narHash": "sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "18e9f9753e9ae261bcc7d3abe15745686991fd30",
+        "rev": "d58f642ddb23320965b27beb0beba7236e9117b5",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1739866667,
-        "narHash": "sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "73cf49b8ad837ade2de76f87eb53fc85ed5d4680",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/ed030a787938cae01d693ebaad52bbb672a4a69d?narHash=sha256-R61wtNknWWejnl%2BK0l4sxu/wnLNFbNe44tNM2zbj5yE%3D' (2025-02-23)
  → 'github:nix-community/home-manager/c12dcc9b61429b2ad437a7d4974399ad8f910319?narHash=sha256-BCeFtoJ/%2BLrZc03viRJWHfzAqqG8gPu/ikZeurv05xs%3D' (2025-02-24)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/18e9f9753e9ae261bcc7d3abe15745686991fd30?narHash=sha256-Y78mDBWoO8CLLTjQfPfII%2BKXFb6lAmF9GrLbyVBsIMM%3D' (2025-02-20)
  → 'github:NixOS/nixos-hardware/d58f642ddb23320965b27beb0beba7236e9117b5?narHash=sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10%3D' (2025-02-24)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/73cf49b8ad837ade2de76f87eb53fc85ed5d4680?narHash=sha256-EO1ygNKZlsAC9avfcwHkKGMsmipUk1Uc0TbrEZpkn64%3D' (2025-02-18)
  → 'github:nixos/nixpkgs/0196c0175e9191c474c26ab5548db27ef5d34b05?narHash=sha256-WGaHVAjcrv%2BCun7zPlI41SerRtfknGQap281%2BAakSAw%3D' (2025-02-24)
```