### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740655786,
-        "narHash": "sha256-CHh/0CxrBx5xWxXwTS9UbHUN/FE86R+g6TjS7Nn4hgE=",
+        "lastModified": 1740673858,
+        "narHash": "sha256-OYKBExCSltpWqk0lUBs4Zo7mofRYcACHOUaMGN7szhU=",
         "owner": "padok-team",
         "repo": "baywatch",
-        "rev": "4c184af90418c941fc20452dd3d765450457f4e7",
+        "rev": "cb456621c85f5e32add972c8892380fd44d69e4d",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740624780,
-        "narHash": "sha256-8TP61AI3QBQsjzVUQFIV8NoB5nbYfJB3iHczhBikDkU=",
+        "lastModified": 1740699498,
+        "narHash": "sha256-r9hkKzX99CGiP1ZqH0e+SWKK4CMsRNRLyotuwrUjhTI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b8869e4ead721bbd4f0d6b927e8395705d4f16e6",
+        "rev": "b71edac7a3167026aabea82a54d08b1794088c21",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1740387674,
-        "narHash": "sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10=",
+        "lastModified": 1740646007,
+        "narHash": "sha256-dMReDQobS3kqoiUCQIYI9c0imPXRZnBubX20yX/G5LE=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d58f642ddb23320965b27beb0beba7236e9117b5",
+        "rev": "009b764ac98a3602d41fc68072eeec5d24fc0e49",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
+        "lastModified": 1740560979,
+        "narHash": "sha256-Vr3Qi346M+8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "rev": "5135c59491985879812717f4c9fea69604e7f26f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'baywatch':
    'github:padok-team/baywatch/4c184af90418c941fc20452dd3d765450457f4e7?narHash=sha256-CHh/0CxrBx5xWxXwTS9UbHUN/FE86R%2Bg6TjS7Nn4hgE%3D' (2025-02-27)
  → 'github:padok-team/baywatch/cb456621c85f5e32add972c8892380fd44d69e4d?narHash=sha256-OYKBExCSltpWqk0lUBs4Zo7mofRYcACHOUaMGN7szhU%3D' (2025-02-27)
• Updated input 'home-manager':
    'github:nix-community/home-manager/b8869e4ead721bbd4f0d6b927e8395705d4f16e6?narHash=sha256-8TP61AI3QBQsjzVUQFIV8NoB5nbYfJB3iHczhBikDkU%3D' (2025-02-27)
  → 'github:nix-community/home-manager/b71edac7a3167026aabea82a54d08b1794088c21?narHash=sha256-r9hkKzX99CGiP1ZqH0e%2BSWKK4CMsRNRLyotuwrUjhTI%3D' (2025-02-27)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d58f642ddb23320965b27beb0beba7236e9117b5?narHash=sha256-pGk/aA0EBvI6o4DeuZsr05Ig/r4uMlSaf5EWUZEWM10%3D' (2025-02-24)
  → 'github:NixOS/nixos-hardware/009b764ac98a3602d41fc68072eeec5d24fc0e49?narHash=sha256-dMReDQobS3kqoiUCQIYI9c0imPXRZnBubX20yX/G5LE%3D' (2025-02-27)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/0196c0175e9191c474c26ab5548db27ef5d34b05?narHash=sha256-WGaHVAjcrv%2BCun7zPlI41SerRtfknGQap281%2BAakSAw%3D' (2025-02-24)
  → 'github:nixos/nixpkgs/5135c59491985879812717f4c9fea69604e7f26f?narHash=sha256-Vr3Qi346M%2B8CjedtbyUevIGDZW8LcA1fTG0ugPY/Hic%3D' (2025-02-26)
```