### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740796616,
-        "narHash": "sha256-JU97wIfRxeFN6rpTsUVCwWAdix+Wka4Or23907YIrFI=",
+        "lastModified": 1740845322,
+        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f0b5e7e8a75abdea32bbff09ddd7b6eeb4b9b445",
+        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740281615,
-        "narHash": "sha256-dZWcbAQ1sF8oVv+zjSKkPVY0ebwENQEkz5vc6muXbKY=",
+        "lastModified": 1740886574,
+        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "465792533d03e6bb9dc849d58ab9d5e31fac9023",
+        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737465171,
-        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "lastModified": 1740870877,
+        "narHash": "sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "rev": "25d4946dfc2021584f5bde1fbd2aa97353384a95",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/f0b5e7e8a75abdea32bbff09ddd7b6eeb4b9b445?narHash=sha256-JU97wIfRxeFN6rpTsUVCwWAdix%2BWka4Or23907YIrFI%3D' (2025-03-01)
  → 'github:nix-community/home-manager/fcac3d6d88302a5e64f6cb8014ac785e08874c8d?narHash=sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw%3D' (2025-03-01)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/465792533d03e6bb9dc849d58ab9d5e31fac9023?narHash=sha256-dZWcbAQ1sF8oVv%2BzjSKkPVY0ebwENQEkz5vc6muXbKY%3D' (2025-02-23)
  → 'github:nix-community/nix-index-database/26a0f969549cf4d56f6e9046b9e0418b3f3b94a5?narHash=sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk%3D' (2025-03-02)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/9364dc02281ce2d37a1f55b6e51f7c0f65a75f17?narHash=sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg%3D' (2025-01-21)
  → 'github:cachix/git-hooks.nix/25d4946dfc2021584f5bde1fbd2aa97353384a95?narHash=sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik%3D' (2025-03-01)
```