### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740695751,
-        "narHash": "sha256-D+R+kFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6313551cd05425cd5b3e63fe47dbc324eabb15e4",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740870877,
-        "narHash": "sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik=",
+        "lastModified": 1740915799,
+        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "25d4946dfc2021584f5bde1fbd2aa97353384a95",
+        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/6313551cd05425cd5b3e63fe47dbc324eabb15e4?narHash=sha256-D%2BR%2BkFxy1KsheiIzkkx/6L63wEHBYX21OIwlFV8JvDs%3D' (2025-02-27)
  → 'github:nixos/nixpkgs/303bd8071377433a2d8f76e684ec773d70c5b642?narHash=sha256-cjbHI%2BzUzK5CPsQZqMhE3npTyYFt9tJ3%2BohcfaOF/WM%3D' (2025-03-01)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/25d4946dfc2021584f5bde1fbd2aa97353384a95?narHash=sha256-LWDIJvKWMW0tiih1jTcAK0ncTi3S9IF3gOhpCT1ydik%3D' (2025-03-01)
  → 'github:cachix/git-hooks.nix/42b1ba089d2034d910566bf6b40830af6b8ec732?narHash=sha256-JvQvtaphZNmeeV%2BIpHgNdiNePsIpHD5U/7QN5AeY44A%3D' (2025-03-02)
```