### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740845322,
-        "narHash": "sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw=",
+        "lastModified": 1741056285,
+        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fcac3d6d88302a5e64f6cb8014ac785e08874c8d",
+        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1740828860,
-        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "lastModified": 1741010256,
+        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739262228,
-        "narHash": "sha256-7JAGezJ0Dn5qIyA2+T4Dt/xQgAbhCglh6lzCekTVMeU=",
+        "lastModified": 1741043164,
+        "narHash": "sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "07af005bb7d60c7f118d9d9f5530485da5d1e975",
+        "rev": "3f2412536eeece783f0d0ad3861417f347219f4d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/fcac3d6d88302a5e64f6cb8014ac785e08874c8d?narHash=sha256-AXEgFj3C0YJhu9k1OhbRhiA6FnDr81dQZ65U3DhaWpw%3D' (2025-03-01)
  → 'github:nix-community/home-manager/70fbbf05a5594b0a72124ab211bff1d502c89e3f?narHash=sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv%2Bcp3rKAgPA%3D' (2025-03-04)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/303bd8071377433a2d8f76e684ec773d70c5b642?narHash=sha256-cjbHI%2BzUzK5CPsQZqMhE3npTyYFt9tJ3%2BohcfaOF/WM%3D' (2025-03-01)
  → 'github:nixos/nixpkgs/ba487dbc9d04e0634c64e3b1f0d25839a0a68246?narHash=sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM%3D' (2025-03-03)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/07af005bb7d60c7f118d9d9f5530485da5d1e975?narHash=sha256-7JAGezJ0Dn5qIyA2%2BT4Dt/xQgAbhCglh6lzCekTVMeU%3D' (2025-02-11)
  → 'github:Mic92/sops-nix/3f2412536eeece783f0d0ad3861417f347219f4d?narHash=sha256-9lfmSZLz6eq9Ygr6cCmvQiiBEaPb54pUBcjvbEMPORc%3D' (2025-03-03)
```