### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741056285,
-        "narHash": "sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv+cp3rKAgPA=",
+        "lastModified": 1741128660,
+        "narHash": "sha256-GWaZ+KGxWYbOB15CSqktwngq0ccA1l2Ov3aUfl9jeY4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "70fbbf05a5594b0a72124ab211bff1d502c89e3f",
+        "rev": "b1b964ea9348aef08cab514fa88e9c99def6fd63",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/70fbbf05a5594b0a72124ab211bff1d502c89e3f?narHash=sha256-/JKDMVqq8PIqcGonBVKbKq1SooV3kzGmv%2Bcp3rKAgPA%3D' (2025-03-04)
  → 'github:nix-community/home-manager/b1b964ea9348aef08cab514fa88e9c99def6fd63?narHash=sha256-GWaZ%2BKGxWYbOB15CSqktwngq0ccA1l2Ov3aUfl9jeY4%3D' (2025-03-04)
```