### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741217763,
-        "narHash": "sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg=",
+        "lastModified": 1741393072,
+        "narHash": "sha256-+Su28oU1FBvptj1AO0geJP+BcIJghSVxaNFagvW5K2M=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "486b066025dccd8af7fbe5dd2cc79e46b88c80da",
+        "rev": "d2c014e1c73195d1958abec0c5ca6112b07b79da",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1741319714,
-        "narHash": "sha256-FY76RS7AIVNNV0TNnd3QetkyCn7PjpP+n9YMKsTBEk4=",
+        "lastModified": 1741325094,
+        "narHash": "sha256-RUAdT8dZ6k/486vnu3tiNRrNW6+Q8uSD2Mq7gTX4jlo=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "d23a3bc3c600a064c72c7fb02862edfab11a46cf",
+        "rev": "b48cc4dab0f9711af296fc367b6108cf7b8ccb16",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740915799,
-        "narHash": "sha256-JvQvtaphZNmeeV+IpHgNdiNePsIpHD5U/7QN5AeY44A=",
+        "lastModified": 1741379162,
+        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "42b1ba089d2034d910566bf6b40830af6b8ec732",
+        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/486b066025dccd8af7fbe5dd2cc79e46b88c80da?narHash=sha256-g/TrltIjFHIjtzKY5CJpoPANfHQWDD43G5U1a/v5oVg%3D' (2025-03-05)
  → 'github:nix-community/home-manager/d2c014e1c73195d1958abec0c5ca6112b07b79da?narHash=sha256-%2BSu28oU1FBvptj1AO0geJP%2BBcIJghSVxaNFagvW5K2M%3D' (2025-03-08)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/d23a3bc3c600a064c72c7fb02862edfab11a46cf?narHash=sha256-FY76RS7AIVNNV0TNnd3QetkyCn7PjpP%2Bn9YMKsTBEk4%3D' (2025-03-07)
  → 'github:NixOS/nixos-hardware/b48cc4dab0f9711af296fc367b6108cf7b8ccb16?narHash=sha256-RUAdT8dZ6k/486vnu3tiNRrNW6%2BQ8uSD2Mq7gTX4jlo%3D' (2025-03-07)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/42b1ba089d2034d910566bf6b40830af6b8ec732?narHash=sha256-JvQvtaphZNmeeV%2BIpHgNdiNePsIpHD5U/7QN5AeY44A%3D' (2025-03-02)
  → 'github:cachix/git-hooks.nix/b5a62751225b2f62ff3147d0a334055ebadcd5cc?narHash=sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc%3D' (2025-03-07)
```