### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741393072,
-        "narHash": "sha256-+Su28oU1FBvptj1AO0geJP+BcIJghSVxaNFagvW5K2M=",
+        "lastModified": 1741461731,
+        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d2c014e1c73195d1958abec0c5ca6112b07b79da",
+        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1740886574,
-        "narHash": "sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk=",
+        "lastModified": 1741490098,
+        "narHash": "sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "26a0f969549cf4d56f6e9046b9e0418b3f3b94a5",
+        "rev": "296a2c992a28b37427d062ade6e20d467e479e3f",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d2c014e1c73195d1958abec0c5ca6112b07b79da?narHash=sha256-%2BSu28oU1FBvptj1AO0geJP%2BBcIJghSVxaNFagvW5K2M%3D' (2025-03-08)
  → 'github:nix-community/home-manager/7f4c60a3d6e548dbc13666565c22cb3f8dcdad44?narHash=sha256-BBQfGvO3GWOV%2B5tmqH14gNcZrRaQ7Q3tQx31Frzoip8%3D' (2025-03-08)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/26a0f969549cf4d56f6e9046b9e0418b3f3b94a5?narHash=sha256-jN6kJ41B6jUVDTebIWeebTvrKP6YiLd1/wMej4uq4Sk%3D' (2025-03-02)
  → 'github:nix-community/nix-index-database/296a2c992a28b37427d062ade6e20d467e479e3f?narHash=sha256-/tjVMbMzxJXrJaEk9N5esnbLebIZrkS1fbDJce/RiQg%3D' (2025-03-09)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/10069ef4cf863633f57238f179a0297de84bd8d3?narHash=sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U%3D' (2025-03-06)
  → 'github:nixos/nixpkgs/36fd87baa9083f34f7f5027900b62ee6d09b1f2f?narHash=sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw%3D' (2025-03-07)
```