### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741461731,
-        "narHash": "sha256-BBQfGvO3GWOV+5tmqH14gNcZrRaQ7Q3tQx31Frzoip8=",
+        "lastModified": 1741579508,
+        "narHash": "sha256-skRbH+UF2ES+msEa+KWi7AQFX73S+QsGlPsyCU6XyE0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7f4c60a3d6e548dbc13666565c22cb3f8dcdad44",
+        "rev": "744f749dd6fbc1489591ea370b95156858629cb9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/7f4c60a3d6e548dbc13666565c22cb3f8dcdad44?narHash=sha256-BBQfGvO3GWOV%2B5tmqH14gNcZrRaQ7Q3tQx31Frzoip8%3D' (2025-03-08)
  → 'github:nix-community/home-manager/744f749dd6fbc1489591ea370b95156858629cb9?narHash=sha256-skRbH%2BUF2ES%2BmsEa%2BKWi7AQFX73S%2BQsGlPsyCU6XyE0%3D' (2025-03-10)
```