### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741635347,
-        "narHash": "sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU=",
+        "lastModified": 1741701235,
+        "narHash": "sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3+91651y3Sqo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7fb8678716c158642ac42f9ff7a18c0800fea551",
+        "rev": "c630dfa8abcc65984cc1e47fb25d4552c81dd37e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/7fb8678716c158642ac42f9ff7a18c0800fea551?narHash=sha256-2aYfV44h18alHXopyfL4D9GsnpE5XlSVkp4MGe586VU%3D' (2025-03-10)
  → 'github:nix-community/home-manager/c630dfa8abcc65984cc1e47fb25d4552c81dd37e?narHash=sha256-gBlb8R9gnjUAT5XabJeel3C2iEUiBHx3%2B91651y3Sqo%3D' (2025-03-11)
```