### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741619381,
-        "narHash": "sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE=",
+        "lastModified": 1742096597,
+        "narHash": "sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "66537fb185462ba9b07f4e6f2d54894a1b2d04ab",
+        "rev": "5c77c6d6f2e8cc6007c2b1a4df1a507834404a67",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741379162,
-        "narHash": "sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc=",
+        "lastModified": 1742058297,
+        "narHash": "sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "b5a62751225b2f62ff3147d0a334055ebadcd5cc",
+        "rev": "59f17850021620cd348ad2e9c0c64f4e6325ce2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/66537fb185462ba9b07f4e6f2d54894a1b2d04ab?narHash=sha256-koZtlJRqi0/MD/AKd0KrXLA2NuBOVzlIyAJprjzpxZE%3D' (2025-03-10)
  → 'github:nix-community/nix-index-database/5c77c6d6f2e8cc6007c2b1a4df1a507834404a67?narHash=sha256-CUy00dj513aIvtN2NGiDKLCVEQSz4xHWSDf229EiJdU%3D' (2025-03-16)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/b5a62751225b2f62ff3147d0a334055ebadcd5cc?narHash=sha256-srpAbmJapkaqGRE3ytf3bj4XshspVR5964OX5LfjDWc%3D' (2025-03-07)
  → 'github:cachix/git-hooks.nix/59f17850021620cd348ad2e9c0c64f4e6325ce2a?narHash=sha256-b4SZc6TkKw8WQQssbN5O2DaCEzmFfvSTPYHlx/SFW9Y%3D' (2025-03-15)
```