### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741955947,
-        "narHash": "sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY=",
+        "lastModified": 1742246081,
+        "narHash": "sha256-1e4oFbtdOOb6NqauHevWWjEUXZnfZ6RUAJJjn9i4YBc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4e12151c9e014e2449e0beca2c0e9534b96a26b4",
+        "rev": "c657142e24a43ea1035889f0b0a7c24598e0e18a",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742180333,
-        "narHash": "sha256-SrvP0G0fxz35lvQxBhAeJOl6+BueIsxJ4azMX+l/kAU=",
+        "lastModified": 1742217307,
+        "narHash": "sha256-3fwpN7KN226ghLlpO9TR0/WpgQOmOj1e8bieUxpIYSk=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "113cd3916682def185290145924fa30b30bda972",
+        "rev": "4f4d97d7b7be387286cc9c988760a7ebaa5be1f1",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741861888,
-        "narHash": "sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0=",
+        "lastModified": 1742239755,
+        "narHash": "sha256-ptn8dR4Uat3UUadGYNnB7CIH9SQm8mK69D2A/twBUXQ=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d016ce0365b87d848a57c12ffcfdc71da7a2b55f",
+        "rev": "787afce414bcce803b605c510b60bf43c11f4b55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/4e12151c9e014e2449e0beca2c0e9534b96a26b4?narHash=sha256-2lbURKclgKqBNm7hVRtWh0A7NrdsibD0EaWhahUVhhY%3D' (2025-03-14)
  → 'github:nix-community/home-manager/c657142e24a43ea1035889f0b0a7c24598e0e18a?narHash=sha256-1e4oFbtdOOb6NqauHevWWjEUXZnfZ6RUAJJjn9i4YBc%3D' (2025-03-17)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/113cd3916682def185290145924fa30b30bda972?narHash=sha256-SrvP0G0fxz35lvQxBhAeJOl6%2BBueIsxJ4azMX%2Bl/kAU%3D' (2025-03-17)
  → 'github:NixOS/nixos-hardware/4f4d97d7b7be387286cc9c988760a7ebaa5be1f1?narHash=sha256-3fwpN7KN226ghLlpO9TR0/WpgQOmOj1e8bieUxpIYSk%3D' (2025-03-17)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/d016ce0365b87d848a57c12ffcfdc71da7a2b55f?narHash=sha256-ynOgXAyToeE1UdLNfrUn/hL7MN0OpIS2BtNdLjpjPf0%3D' (2025-03-13)
  → 'github:Mic92/sops-nix/787afce414bcce803b605c510b60bf43c11f4b55?narHash=sha256-ptn8dR4Uat3UUadGYNnB7CIH9SQm8mK69D2A/twBUXQ%3D' (2025-03-17)
```