### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742530487,
-        "narHash": "sha256-yjBjRn294NpPagPAQCio20X5BzBXiOoz2+xF3/YmEkU=",
+        "lastModified": 1742588233,
+        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d61711497be9ad6a6633aaf203b038b5a970621f",
+        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733156752,
-        "narHash": "sha256-zTQNU0u0eF+B7HeYAIQI3KQj8Jwd6dZ0AG1KsjEOXkA=",
+        "lastModified": 1742581852,
+        "narHash": "sha256-FgiCbOkBtPzidoLb2RIeaeAJUhKbDWjKIwmaF6k12ds=",
         "owner": "kolide",
         "repo": "nix-agent",
-        "rev": "d154b67a88e9cf8a6c10fd589afd51b299f7faca",
+        "rev": "e4a6b5e05a79dd10bceb98032f3b2681ec71eab0",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742406979,
-        "narHash": "sha256-r0aq70/3bmfjTP+JZs4+XV5SgmCtk1BLU4CQPWGtA7o=",
+        "lastModified": 1742595978,
+        "narHash": "sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "1770be8ad89e41f1ed5a60ce628dd10877cb3609",
+        "rev": "b7756921b002de60fb66782effad3ce8bdb5b25d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/d61711497be9ad6a6633aaf203b038b5a970621f?narHash=sha256-yjBjRn294NpPagPAQCio20X5BzBXiOoz2%2BxF3/YmEkU%3D' (2025-03-21)
  → 'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d?narHash=sha256-Fi5g8H5FXMSRqy%2BmU6gPG0v%2BC9pzjYbkkiePtz8%2BPpA%3D' (2025-03-21)
• Updated input 'kolide-launcher':
    'github:kolide/nix-agent/d154b67a88e9cf8a6c10fd589afd51b299f7faca?narHash=sha256-zTQNU0u0eF%2BB7HeYAIQI3KQj8Jwd6dZ0AG1KsjEOXkA%3D' (2024-12-02)
  → 'github:kolide/nix-agent/e4a6b5e05a79dd10bceb98032f3b2681ec71eab0?narHash=sha256-FgiCbOkBtPzidoLb2RIeaeAJUhKbDWjKIwmaF6k12ds%3D' (2025-03-21)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/1770be8ad89e41f1ed5a60ce628dd10877cb3609?narHash=sha256-r0aq70/3bmfjTP%2BJZs4%2BXV5SgmCtk1BLU4CQPWGtA7o%3D' (2025-03-19)
  → 'github:Mic92/sops-nix/b7756921b002de60fb66782effad3ce8bdb5b25d?narHash=sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU%3D' (2025-03-21)
```