### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742588233,
-        "narHash": "sha256-Fi5g8H5FXMSRqy+mU6gPG0v+C9pzjYbkkiePtz8+PpA=",
+        "lastModified": 1742701794,
+        "narHash": "sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "296ddc64627f4a6a4eb447852d7346b9dd16197d",
+        "rev": "9172a6f956f7e0f7810861b9b1146f1c43d9abcb",
         "type": "github"
       },
       "original": {
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742174123,
-        "narHash": "sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y=",
+        "lastModified": 1742701275,
+        "narHash": "sha256-AulwPVrS9859t+eJ61v24wH/nfBEIDSXYxlRo3fL/SA=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c",
+        "rev": "36dc43cb50d5d20f90a28d53abb33a32b0a2aae6",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742376361,
-        "narHash": "sha256-VFMgJkp/COvkt5dnkZB4D2szVdmF6DGm5ZdVvTUy61c=",
+        "lastModified": 1742631601,
+        "narHash": "sha256-yJ3OOAmsGAxSl0bTmKUp3+cEYtSS+V6hUPK2rYhIPr8=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "daaae13dff0ecc692509a1332ff9003d9952d7a9",
+        "rev": "380ed15bcd6440606c6856db44a99140d422b46f",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742300892,
-        "narHash": "sha256-QmF0proyjXI9YyZO9GZmc7/uEu5KVwCtcdLsKSoxPAI=",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ea26a82dda75bee6783baca6894040c8e6599728",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742595978,
-        "narHash": "sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU=",
+        "lastModified": 1742700801,
+        "narHash": "sha256-ZGlpUDsuBdeZeTNgoMv+aw0ByXT2J3wkYw9kJwkAS4M=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b7756921b002de60fb66782effad3ce8bdb5b25d",
+        "rev": "67566fe68a8bed2a7b1175fdfb0697ed22ae8852",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/296ddc64627f4a6a4eb447852d7346b9dd16197d?narHash=sha256-Fi5g8H5FXMSRqy%2BmU6gPG0v%2BC9pzjYbkkiePtz8%2BPpA%3D' (2025-03-21)
  → 'github:nix-community/home-manager/9172a6f956f7e0f7810861b9b1146f1c43d9abcb?narHash=sha256-bJIFFa6/4vBGoNmCwjO5TCIbiveV2BRxVLqHcxk5jXw%3D' (2025-03-23)
• Updated input 'nix-index-database':
    'github:nix-community/nix-index-database/2cfb4e1ca32f59dd2811d7a6dd5d4d1225f0955c?narHash=sha256-pDNzMoR6m1ZSJToZQ6XDTLVSdzIzmFl1b8Pc3f7iV6Y%3D' (2025-03-17)
  → 'github:nix-community/nix-index-database/36dc43cb50d5d20f90a28d53abb33a32b0a2aae6?narHash=sha256-AulwPVrS9859t%2BeJ61v24wH/nfBEIDSXYxlRo3fL/SA%3D' (2025-03-23)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/daaae13dff0ecc692509a1332ff9003d9952d7a9?narHash=sha256-VFMgJkp/COvkt5dnkZB4D2szVdmF6DGm5ZdVvTUy61c%3D' (2025-03-19)
  → 'github:NixOS/nixos-hardware/380ed15bcd6440606c6856db44a99140d422b46f?narHash=sha256-yJ3OOAmsGAxSl0bTmKUp3%2BcEYtSS%2BV6hUPK2rYhIPr8%3D' (2025-03-22)
• Updated input 'pre-commit-hooks':
    'github:cachix/git-hooks.nix/ea26a82dda75bee6783baca6894040c8e6599728?narHash=sha256-QmF0proyjXI9YyZO9GZmc7/uEu5KVwCtcdLsKSoxPAI%3D' (2025-03-18)
  → 'github:cachix/git-hooks.nix/dcf5072734cb576d2b0c59b2ac44f5050b5eac82?narHash=sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco%3D' (2025-03-22)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/b7756921b002de60fb66782effad3ce8bdb5b25d?narHash=sha256-05onsoMrLyXE4XleDCeLC3bXnC4nyUbKWInGwM7v6hU%3D' (2025-03-21)
  → 'github:Mic92/sops-nix/67566fe68a8bed2a7b1175fdfb0697ed22ae8852?narHash=sha256-ZGlpUDsuBdeZeTNgoMv%2Baw0ByXT2J3wkYw9kJwkAS4M%3D' (2025-03-23)
```