### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742771635,
-        "narHash": "sha256-HQHzQPrg+g22tb3/K/4tgJjPzM+/5jbaujCZd8s2Mls=",
+        "lastModified": 1742871411,
+        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818",
+        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1742631601,
-        "narHash": "sha256-yJ3OOAmsGAxSl0bTmKUp3+cEYtSS+V6hUPK2rYhIPr8=",
+        "lastModified": 1742806253,
+        "narHash": "sha256-zvQ4GsCJT6MTOzPKLmlFyM+lxo0JGQ0cSFaZSACmWfY=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "380ed15bcd6440606c6856db44a99140d422b46f",
+        "rev": "ecaa2d911e77c265c2a5bac8b583c40b0f151726",
         "type": "github"
       },
       "original": {
@@ -161,11 +161,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1737038300,
-        "narHash": "sha256-N9bMW7Bw/1xLB58j8rbXS1Qh4LRk47LgzIk0xwJ1dqs=",
+        "lastModified": 1742832358,
+        "narHash": "sha256-ljTdVKjjwzEZOn7A4Li6ih61hiDzswXdq/9Zhs4A+DE=",
         "owner": "cterence",
         "repo": "nixos-work-config",
-        "rev": "5eed56075fc354ff5acdaf16246f5090989328dc",
+        "rev": "47bc0776cd5b3708cad2408c38ef014d98a8edc8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/ad0614a1ec9cce3b13169e20ceb7e55dfaf2a818?narHash=sha256-HQHzQPrg%2Bg22tb3/K/4tgJjPzM%2B/5jbaujCZd8s2Mls%3D' (2025-03-23)
  → 'github:nix-community/home-manager/869f2ec2add75ce2a70a6dbbf585b8399abec625?narHash=sha256-F3xBdOs5m0SE6Gq3jz%2BJxDOPvsLs22vbGfD05uF6xEc%3D' (2025-03-25)
• Updated input 'nixos-hardware':
    'github:NixOS/nixos-hardware/380ed15bcd6440606c6856db44a99140d422b46f?narHash=sha256-yJ3OOAmsGAxSl0bTmKUp3%2BcEYtSS%2BV6hUPK2rYhIPr8%3D' (2025-03-22)
  → 'github:NixOS/nixos-hardware/ecaa2d911e77c265c2a5bac8b583c40b0f151726?narHash=sha256-zvQ4GsCJT6MTOzPKLmlFyM%2Blxo0JGQ0cSFaZSACmWfY%3D' (2025-03-24)
• Updated input 'nixos-work-config':
    'github:cterence/nixos-work-config/5eed56075fc354ff5acdaf16246f5090989328dc?narHash=sha256-N9bMW7Bw/1xLB58j8rbXS1Qh4LRk47LgzIk0xwJ1dqs%3D' (2025-01-16)
  → 'github:cterence/nixos-work-config/47bc0776cd5b3708cad2408c38ef014d98a8edc8?narHash=sha256-ljTdVKjjwzEZOn7A4Li6ih61hiDzswXdq/9Zhs4A%2BDE%3D' (2025-03-24)
```