### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742871411,
-        "narHash": "sha256-F3xBdOs5m0SE6Gq3jz+JxDOPvsLs22vbGfD05uF6xEc=",
+        "lastModified": 1742957044,
+        "narHash": "sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "869f2ec2add75ce2a70a6dbbf585b8399abec625",
+        "rev": "ce287a5cd3ef78203bc78021447f937a988d9f6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/869f2ec2add75ce2a70a6dbbf585b8399abec625?narHash=sha256-F3xBdOs5m0SE6Gq3jz%2BJxDOPvsLs22vbGfD05uF6xEc%3D' (2025-03-25)
  → 'github:nix-community/home-manager/ce287a5cd3ef78203bc78021447f937a988d9f6f?narHash=sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c%3D' (2025-03-26)
```