### PR TITLE
chore(flake.lock): update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742957044,
-        "narHash": "sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c=",
+        "lastModified": 1742996658,
+        "narHash": "sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "ce287a5cd3ef78203bc78021447f937a988d9f6f",
+        "rev": "693840c01b9bef9e54100239cef937e53d4661bf",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742669843,
-        "narHash": "sha256-G5n+FOXLXcRx+3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1e5b653dff12029333a6546c11e108ede13052eb",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
```
Flake lock file updates:

• Updated input 'home-manager':
    'github:nix-community/home-manager/ce287a5cd3ef78203bc78021447f937a988d9f6f?narHash=sha256-gwW0tBIA77g6qq45y220drTy0DmThF3fJMwVFUtYV9c%3D' (2025-03-26)
  → 'github:nix-community/home-manager/693840c01b9bef9e54100239cef937e53d4661bf?narHash=sha256-snxgTLVq6ooaD3W3mPHu7LVWpoZKczhxHAUZy2ea4oA%3D' (2025-03-26)
• Updated input 'nixpkgs':
    'github:nixos/nixpkgs/1e5b653dff12029333a6546c11e108ede13052eb?narHash=sha256-G5n%2BFOXLXcRx%2B3hCJ6Rt6ZQyF1zqQ0DL0sWAMn2Nk0w%3D' (2025-03-22)
  → 'github:nixos/nixpkgs/698214a32beb4f4c8e3942372c694f40848b360d?narHash=sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw%3D' (2025-03-25)
```